### PR TITLE
Removing (seemingly) unnecessary dependency on ruby 1.9.3.

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -14,5 +14,4 @@ Gem::Specification.new do |s|
   s.add_dependency('gherkin', '~> 2.7.1')
   s.add_dependency('nokogiri', '~> 1.5.0')
   s.files = Dir['lib/**/*.rb']
-  s.required_ruby_version = '>= 1.9.3'
 end


### PR DESCRIPTION
Opscode will be shipping ruby 1.9.2 embedded in it's omnibus builds for both client and server. This gem is awesome and crazy useful, and should be compatible with mainline chef's environment
