### PR TITLE
Numeric value for mode should be 5 digits (CHEF-174)

### DIFF
--- a/features/006_check_file_mode.feature
+++ b/features/006_check_file_mode.feature
@@ -16,7 +16,7 @@ Feature: Check file mode
       | cookbook_file | 00644  |   valid             |
       | directory     |   755  | invalid             |
       | directory     |  "755" |   valid             |
-      | directory     |  0644  |   valid             |
+      | directory     |  0644  | invalid             |
       | directory     | "0644" |   valid             |
       | directory     |   400  | invalid             |
       | directory     | 00400  |   valid             |

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -48,7 +48,7 @@ end
 rule "FC006", "Mode should be quoted or fully specified when setting file permissions" do
   tags %w{correctness files}
   recipe do |ast|
-    ast.xpath(%q{//ident[@value='mode']/parent::command/descendant::int[string-length(@value) < 4]/
+    ast.xpath(%q{//ident[@value='mode']/parent::command/descendant::int[string-length(@value) < 5]/
       ancestor::method_add_block}).map{|resource| match(resource)}
   end
 end


### PR DESCRIPTION
In FC006, numeric value for mode should be 5 digits to ensure that ruby (jruby) parses the mode correctly. I actually run into this one myself with jruby.

As seen in
http://wiki.opscode.com/display/chef/Resources#Resources-CookbookFile
"A note about mode: When specifying the mode, the value can be a quoted string, eg "644". For a numeric value (i.e., without quotes), it should be 5 digits, e.g., 00644 to ensure that Ruby can parse it correctly. For more detail, see Ticket CHEF-174."

Given how working with numbers in Ruby can be tricky, "FC002: Avoid string interpolation where not required" does not sound like a good advice. My rule of thumb - quote unless you are really really sure.
