### PR TITLE
Updating the rule to treat 0xxx modes as valid

### DIFF
--- a/features/006_check_file_mode.feature
+++ b/features/006_check_file_mode.feature
@@ -16,7 +16,7 @@ Feature: Check file mode
       | cookbook_file | 00644  |   valid             |
       | directory     |   755  | invalid             |
       | directory     |  "755" |   valid             |
-      | directory     |  0644  | invalid             |
+      | directory     |  0644  |   valid             |
       | directory     | "0644" |   valid             |
       | directory     |   400  | invalid             |
       | directory     | 00400  |   valid             |

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -48,7 +48,7 @@ end
 rule "FC006", "Mode should be quoted or fully specified when setting file permissions" do
   tags %w{correctness files}
   recipe do |ast|
-    ast.xpath(%q{//ident[@value='mode']/parent::command/descendant::int[string-length(@value) < 5]/
+    ast.xpath(%q{//ident[@value='mode']/parent::command/descendant::int[string-length(@value) < 5 and not(starts-with(@value, "0") and string-length(@value) = 4)]/
       ancestor::method_add_block}).map{|resource| match(resource)}
   end
 end


### PR DESCRIPTION
What do you think about this XPath change to make the 0xxx mode valid? 
