### PR TITLE
Allow linting of individual files

### DIFF
--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -80,7 +80,7 @@ module FoodCritic
     #
     # @return [Boolean] True if the path is a directory that exists.
     def valid_path?
-      @args.length == 1 and Dir.exists?(@args[0])
+      @args.length == 1 and File.exists?(@args[0])
     end
 
     # The cookbook path

--- a/spec/foodcritic/command_line_spec.rb
+++ b/spec/foodcritic/command_line_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../spec_helper'
+
+describe FoodCritic::CommandLine do
+  it "is instantiable" do
+    FoodCritic::CommandLine.new([]).wont_be_nil
+  end
+
+  describe "#valid_path?" do
+    it "returns true if the specified directory exists" do
+      assert FoodCritic::CommandLine.new(["lib"]).valid_path?
+    end
+
+    it "returns false if the specified directory does not exist" do
+      refute FoodCritic::CommandLine.new(["lib2"]).valid_path?
+    end
+
+    it "returns true if the specified file exists" do
+      assert FoodCritic::CommandLine.new(["lib/foodcritic.rb"]).valid_path?
+    end
+  end
+end


### PR DESCRIPTION
I'm working on a guard plugin for foodcritic and opening up the command line argument validation to allow what the library already supports will help make the guard plugin much easier.
