### PR TITLE
Changed require at the features to test the actual current code

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,7 +5,7 @@ end
 
 require 'aruba/cucumber'
 require 'pry'
-require 'foodcritic'
+require_relative '../../lib/foodcritic'
 
 Before do
   @aruba_timeout_seconds = 300


### PR DESCRIPTION
Hi,

I was trying the features and it fails me trying to load the _foodcritic_ lib because I was in a fresh gemset and `bundle install` didn't install the gem, but actually it won't be right either.

The code to test should be the one at the repo and not the one installed at the system, which could be another version.

Right now the `features/support/env.rb` require _foodcritic_ from the installed gem, instead of the code at the repo, so I changed it to require the local one.

Thanks
