### PR TITLE
Add :exclude_paths to the comman line options

### DIFF
--- a/features/exclude_paths_to_lint.feature
+++ b/features/exclude_paths_to_lint.feature
@@ -1,0 +1,19 @@
+Feature: Exclude paths from being linted
+
+  In order to avoid lint some paths that are not really from the cookbook
+  As a developer
+  I want to be able to exclude some files or directories from the passed paths
+
+  Scenario: Don't exclude a non cookbook directory
+    Given a cookbook that has style problems
+      And unit tests under a top-level test directory
+     When I check the cookbook without excluding the test directory
+     Then warnings will be displayed against the tests
+      And the style warning 002 should be displayed
+
+  Scenario: Exclude a non cookbook directory
+    Given a cookbook that has style problems
+      And unit tests under a top-level test directory
+     When I check the cookbook excluding the test directory
+     Then no warnings will be displayed against the tests
+      And the style warning 002 should be displayed

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -904,6 +904,11 @@ When 'I check the cookbook without specifying a Chef version' do
   run_lint(['-I', 'rules/test.rb', 'cookbooks/example'])
 end
 
+When /^I check the cookbook( without)? excluding the ([^ ]+) directory$/ do |no_exclude, dir|
+  options = no_exclude.nil? ? ['-E', dir] : []
+  run_lint(options + ['cookbooks/example'])
+end
+
 When 'I check the recipe' do
   run_lint(["cookbooks/example/recipes/default.rb"])
 end
@@ -1022,8 +1027,12 @@ Then 'no error should have occurred' do
   assert_no_error_occurred
 end
 
-Then /^no warnings will be displayed against the tests$/ do
-  assert_no_test_warnings
+Then /^(no )?warnings will be displayed against the tests$/ do |no_display|
+  if no_display.nil?
+    assert_test_warnings
+  else
+    assert_no_test_warnings
+  end
 end
 
 Then /^the warning should (not )?be displayed$/ do |should_not|

--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -123,6 +123,7 @@ module FoodCritic
       expect_usage_option('t', 'tags TAGS', 'Only check against rules with the specified tags.')
       expect_usage_option('C', '[no-]context', 'Show lines matched against rather than the default summary.')
       expect_usage_option('I', 'include PATH', 'Additional rule file path(s) to load.')
+      expect_usage_option('E', 'exclude PATH', 'Exclude path(s) from being linted.')
       expect_usage_option('S', 'search-grammar PATH', 'Specify grammar to use when validating search syntax.')
       expect_usage_option('V', 'version', 'Display the foodcritic version.')
       if is_exit_zero
@@ -167,6 +168,22 @@ module FoodCritic
     # Assert that no error occurred following a lint check.
     def assert_no_error_occurred
       @status.should == 0
+    end
+
+    # Assert that warnings have not been raised against the test code which
+    # should have been excluded from linting.
+    def assert_no_test_warnings
+      @review.split("\n").grep(/FC[0-9]+:/).map do |warn|
+        File.basename(File.dirname(warn.split(':').take(3).last.strip))
+      end.should_not include 'test'
+    end
+
+    # Assert that warnings have been raised against the test code which
+    # shouldn't have been excluded from linting.
+    def assert_test_warnings
+      @review.split("\n").grep(/FC[0-9]+:/).map do |warn|
+        File.basename(File.dirname(warn.split(':').take(3).last.strip))
+      end.should include 'test'
     end
 
     # Run a lint check with the provided command line arguments.

--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -9,7 +9,12 @@ module FoodCritic
     def initialize(args)
       @args = args
       @original_args = args.dup
-      @options = {:fail_tags => [], :tags => [], :include_rules => []}
+      @options = {
+        :fail_tags => [],
+        :tags => [],
+        :include_rules => [],
+        :exclude_paths => []
+      }
       @parser = OptionParser.new do |opts|
         opts.banner = 'foodcritic [cookbook_paths]'
         opts.on("-r", "--[no-]repl",
@@ -35,6 +40,10 @@ module FoodCritic
         opts.on("-I", "--include PATH",
           "Additional rule file path(s) to load.") do |i|
           options[:include_rules] << i
+        end
+        opts.on("-E", "--exclude PATH",
+          "Exclude path(s) from being linted.") do |e|
+          options[:exclude_paths] << e
         end
         opts.on("-S", "--search-grammar PATH",
           "Specify grammar to use when validating search syntax.") do |s|

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -129,10 +129,10 @@ module FoodCritic
     # to match rules against.
     def files_to_process(dirs, exclude_paths = [])
       files = []
+      cookbook_glob = '{metadata.rb,{attributes,libraries,providers,recipes,resources}/*.rb}'
       dirs.each do |dir|
-        exclusions = Dir.glob(exclude_paths.map{|p| File.join(dir, p)})
+        exclusions = Dir.glob(exclude_paths.map{|p| File.join(dir, p, cookbook_glob)})
         if File.directory? dir
-          cookbook_glob = '{metadata.rb,{attributes,libraries,providers,recipes,resources}/*.rb}'
           files += (Dir.glob(File.join(dir, cookbook_glob)) +
             Dir.glob(File.join(dir, "*/#{cookbook_glob}")) - exclusions)
         else


### PR DESCRIPTION
Add the option `:exclude_paths`, that already exists, to the command line options.