### PR TITLE
Add help message when invalid option is passed

### DIFF
--- a/features/command_line_help.feature
+++ b/features/command_line_help.feature
@@ -28,3 +28,8 @@ Feature: Command line help
     Given I have installed the lint tool
      When I run it on the command line with the unimplemented verbose option
      Then the simple usage text should be displayed along with a non-zero exit code
+
+  Scenario: Unimplemented option
+    Given I have installed the lint tool
+     When I run it on the command line with the unimplemented -Z option
+     Then the simple usage text should be displayed along with a non-zero exit code

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -955,12 +955,12 @@ When 'I run it on the command line with no arguments' do
   run_lint([])
 end
 
-When /^I run it on the command line with the ([^ ]+) option$/ do |long_option|
-  run_lint(["--#{long_option}"])
-end
-
-When 'I run it on the command line with the unimplemented verbose option' do
-  run_lint(['-v'])
+When /^I run it on the command line with the (?:unimplemented |)([^ ]+) option$/ do |option|
+  if option.match(/\-\w$/)
+    run_lint([option])
+  else
+    run_lint(["--#{option}"])
+  end
 end
 
 When 'I run the build' do

--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -45,7 +45,11 @@ module FoodCritic
           options[:version] = true
         end
       end
-      @parser.parse!(args) unless show_help?
+      begin
+        @parser.parse!(args) unless show_help?
+      rescue OptionParser::InvalidOption => e
+        e.recover args
+      end
     end
 
     # Show the command help to the end user?


### PR DESCRIPTION
When I was working on the tests for the `:exclude_paths` option (#45), I realized that the `InvalidOptions` were supposed to be controled, but they weren't.

The test for the _unimplemented_ option **verbose** actually weren't working because the short option `-v` did exists and it was called to `:version`, so it was showing the Foodcritic's version instead of the usage text.

I did some changes at the text and added a new one to test short and long unimplemented options and I added the code to control this exception and show the usage text.

I understand this is the expected behavior, isn't it?
