### PR TITLE
Do not require an empty array if just using default options

### DIFF
--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -43,7 +43,7 @@ module FoodCritic
     # * `:fail_tags` - The tags to fail the build on
     # * `:exclude_paths` - Paths to exclude from linting
     #
-    def check(cookbook_paths, options)
+    def check(cookbook_paths, options = {})
 
       cookbook_paths = sanity_check_cookbook_paths(cookbook_paths)
       options = setup_defaults(options)

--- a/spec/foodcritic/linter_spec.rb
+++ b/spec/foodcritic/linter_spec.rb
@@ -35,6 +35,9 @@ describe FoodCritic::Linter do
     it "returns a review" do
       linter.check(['.'], {}).must_respond_to(:warnings)
     end
+    it "does not require an empty hash of options" do
+      linter.check(['.'])
+    end
   end
 
 end


### PR DESCRIPTION
Small thing, just don't bother making people specify an empty array to use the default options.
