### PR TITLE
Reduce unnecessary blank lines from console output if there's nothing to print

### DIFF
--- a/lib/foodcritic/rake_task.rb
+++ b/lib/foodcritic/rake_task.rb
@@ -24,8 +24,11 @@ module FoodCritic
         desc "Lint Chef cookbooks"
         task(name) do
           result = FoodCritic::Linter.new.check(files, options)
-          puts result
-          fail if result.failed?
+          if result.warnings.any?
+            puts result
+          end
+
+          fail result.to_s if result.failed?
         end
       end
 


### PR DESCRIPTION
We run foodcritic tests for a lot of cookbooks:

```
  Dir["cookbooks/*"].each do |cookbook_dir|
    cookbook_name = File.basename(cookbook_dir)
    FoodCritic::Rake::LintTask.new(cookbook_name) do |t|
        t.files = cookbook_dir
        t.options = ...
    end
```

This outputs one line of console output for each task that is defined. Even if there's nothing to warn the user about.

This patch ensures that we only print the food critic reviews if there's a warning and fail with a proper message if there's any, thereby preventing a blank line from being printed.
