### PR TITLE
Add spec/**/* and features/**/* to default rake task :exclude_paths.

### DIFF
--- a/lib/foodcritic/rake_task.rb
+++ b/lib/foodcritic/rake_task.rb
@@ -17,7 +17,8 @@ module FoodCritic
 
       def options
         {:fail_tags => ['correctness'], # differs to default cmd-line behaviour
-         :exclude_paths => ['test/**/*']}.merge(@options)
+         :exclude_paths => ['test/**/*', 'spec/**/*', 'features/**/*']
+        }.merge(@options)
       end
 
       def define


### PR DESCRIPTION
Hey Andrew,

Pretty straight forward one here, but would help a default Rake task and [thor-foodcritic](https://github.com/reset/thor-foodcritic/) with reasonable convention defaults.

Thanks! <3 <3 <3
