### PR TITLE
don't look at the function calls on resource attributes

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -398,8 +398,8 @@ module FoodCritic
               fcall[ident/@value='#{block_att}']) = 0")
           end
 
-          unless att.xpath('string(ident/@value | fcall/ident/@value)').empty?
-            atts[att.xpath('string(ident/@value | fcall/ident/@value)')] =
+          unless att.xpath('string(ident/@value)').empty?
+            atts[att.xpath('string(ident/@value)')] =
               extract_attribute_value(att, options)
           end
       end


### PR DESCRIPTION
I had a lot of false positives on the rule "FC009: Resource attribute not recognised" It treats all function calls made to the values of attributes as a resource attribute and reports it as a violation.

In the following example, `rand` function call is considered as a resource attribute and reported as a violation.

``` ruby
cron "run a command at a random minute" do
  user      "root"
  minute    rand(60)
  command   "/usr/bin/whatever"
end
```

So In the code I've removed looking in `fcal` blocks in the `normal_attributes` function of `api.rb`. The only place to use this function is to check this FC009 rule and I don't see why we should check the function calls here. Correct me if I'm wrong.
