### PR TITLE
parse :'symbol' notification actions

### DIFF
--- a/lib/foodcritic/notifications.rb
+++ b/lib/foodcritic/notifications.rb
@@ -123,7 +123,8 @@ module FoodCritic
     end
 
     def notification_action(notify)
-      notify.xpath('descendant::symbol[1]/ident/@value').to_s.to_sym
+      notify.xpath('descendant::symbol[1]/ident/@value |
+        descendant::dyna_symbol[1]/xstring_add/tstring_content/@value').first.to_s.to_sym
     end
 
     def notification_nodes(ast, &block)

--- a/spec/foodcritic/api_spec.rb
+++ b/spec/foodcritic/api_spec.rb
@@ -560,6 +560,25 @@ describe FoodCritic::Api do
         }]
       )
     end
+    it "understands old-style notifications with :'symbol' literals as action" do
+      api.notifications(parse_ast(%q{
+        template "/etc/nscd.conf" do
+          source "nscd.conf"
+          owner "root"
+          group "root"
+          notifies :'soft-restart', resources(:service => "nscd")
+        end
+      })).must_equal(
+        [{
+          :type => :notifies,
+          :action => :'soft-restart',
+          :resource_type => :service,
+          :resource_name => 'nscd',
+          :timing => :delayed,
+          :style => :old
+        }]
+      )
+    end
     it "understands old-style notifications with added parentheses" do
       api.notifications(parse_ast(%q{
         template "/etc/nscd.conf" do


### PR DESCRIPTION
I ran into this issue with a cookbook we maintain internally. It uses `:'soft-restart'` as a notification action. This patch allows parsing these actions correctly.
