### PR TITLE
ignore rules via comment on the offending line

### DIFF
--- a/features/ignore_via_line_comments.feature
+++ b/features/ignore_via_line_comments.feature
@@ -1,0 +1,15 @@
+Feature: Ignoring rules on per line basis
+
+  To ignore specific warnings on some lines
+  As a developer
+  I want to add a ignore comment
+
+  Scenario: Not ignoring
+    Given a resource resource declared with the mode 644
+    When I check the cookbook
+    Then the file mode warning 006 should be invalid
+
+  Scenario: Ignoring
+    Given a resource resource declared with the mode 644 ignored from FC006
+    When I check the cookbook
+    Then the file mode warning 006 should be valid

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -1,5 +1,9 @@
-Given /^a ([a-z_])+ resource declared with the mode (.*)$/ do |resource,mode|
-  recipe_resource_with_mode(resource, mode)
+Given /^a ([a-z_])+ resource declared with the mode ([^\s]*)(?: ignored from (.*))?$/ do |resource,mode,ignored_rule|
+  recipe_resource_with_mode(resource, mode, ignored_rule)
+end
+
+Given /^the line is ignored from (.*)$/ do |resource,mode|
+  write_file "cookbooks/#{cookbook_name}/recipes/default.rb", content.strip
 end
 
 Given 'a cookbook attributes file that declares and refers to a local variable' do

--- a/features/support/cookbook_helpers.rb
+++ b/features/support/cookbook_helpers.rb
@@ -237,10 +237,11 @@ module FoodCritic
     #
     # @param [String] type The type of resource (file, template)
     # @param [String] mode The file mode as a string
-    def recipe_resource_with_mode(type, mode)
+    # @param [String] code of rule that is ignored
+    def recipe_resource_with_mode(type, mode, ignored_rule=nil)
       source_att = type == 'template' ? 'source "foo.erb"' : ''
       write_recipe %Q{
-        #{type} "/tmp/something" do
+        #{type} "/tmp/something" do#{ " # ignore #{ignored_rule}" if ignored_rule}
           #{source_att}
           owner "root"
           group "root"

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -70,6 +70,8 @@ module FoodCritic
             rule_matches += matches(rule.cookbook, cookbook_dir(file))
           end
 
+          remove_ignored!(rule_matches, rule, file)
+
           # Convert the matches into warnings
           rule_matches.each do |match|
             warnings << Warning.new(rule, {:filename => file}.merge(match))
@@ -94,6 +96,16 @@ module FoodCritic
     end
 
     private
+
+    def remove_ignored!(matches, rule, file)
+      matches.reject! do |m|
+        (
+          (line = m[:line]) &&
+          File.exist?(file) &&
+          File.readlines(file)[line-1].to_s =~ /# ignore #{rule.code}/
+        )
+      end
+    end
 
     # Some rules are version specific.
     def applies_to_version?(rule, version)


### PR DESCRIPTION
@acrmp

fixes #115 + maybe #10 / #57
- allows for selective ignoring without disabling the rule as a whole
- leaves a todo style comment `# ignore FC006 -- we need to do crazy stuff here because abc`
- does not require an extra file that can get invalid when lines/code move around
