### PR TITLE
Fix deprecation warnings from Gherkin

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://acrmp.github.com/foodcritic'
   s.license = 'MIT'
   s.executables << 'foodcritic'
-  s.add_dependency('gherkin', '~> 2.11.1')
+  s.add_dependency('gherkin', '~> 2.11.7')
   s.add_dependency('nokogiri', '~> 1.5.4')
   s.add_dependency('rak', '~> 1.4')
   s.add_dependency('treetop', '~> 1.4.10')

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -190,7 +190,7 @@ module FoodCritic
 
     # We use the Gherkin (Cucumber) syntax to specify tags.
     def matching_tags?(tag_expr, tags)
-      Gherkin::TagExpression.new(tag_expr).eval(tags.map do |t|
+      Gherkin::TagExpression.new(tag_expr).evaluate(tags.map do |t|
         Gherkin::Formatter::Model::Tag.new(t, 1)
       end)
     end


### PR DESCRIPTION
Gherkin 2.11.7 [deprecated](https://github.com/cucumber/gherkin/commit/240b00a5) `TagExpression.eval` and added `TagExpression.evaluate` to replace it. The new version causes lots of warnings:

```
[DEPRECATION] "eval" is deprecated. Please use "evaluate" instead
```

This PR removes the warnings by using the new `evaluate` method and upgrade the gherking dependency to `~> 2.11.7` where that method is introduced.
