### PR TITLE
Issue 143 - Provide a search rubygems option to load custom rules from a gem.

### DIFF
--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -32,6 +32,10 @@ module FoodCritic
           "Additional rule file path(s) to load.") do |i|
           options[:include_rules] << i
         end
+        opts.on("-G", "--search-gems",
+          "Search rubygems for rule files with the path foodcritic/rules/**/*.rb") do |g|
+          options[:search_gems] = true
+        end
         opts.on("-S", "--search-grammar PATH",
           "Specify grammar to use when validating search syntax.") do |s|
           options[:search_grammar] = s

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -39,6 +39,7 @@ module FoodCritic
     # The `options` are a hash where the valid keys are:
     #
     # * `:include_rules` - Paths to additional rules to apply
+    # * `:search_gems - If true then search for custom rules in installed gems.
     # * `:tags` - The tags to filter rules based on
     # * `:fail_tags` - The tags to fail the build on
     # * `:exclude_paths` - Paths to exclude from linting
@@ -93,8 +94,10 @@ module FoodCritic
     end
 
     def load_rules!(options)
-      @rules = RuleDsl.load([File.join(File.dirname(__FILE__), 'rules.rb')] +
-        options[:include_rules], chef_version)
+      rule_files = [File.join(File.dirname(__FILE__), 'rules.rb')]
+      rule_files << options[:include_rules]
+      rule_files << Gem.find_files('foodcritic/rules/**/*.rb') if options[:search_gems]
+      @rules = RuleDsl.load(rule_files.flatten.compact, chef_version)
     end
 
     private


### PR DESCRIPTION
- Added search for ruby gems option -G (or --search-gems)
- If option is given then search gems for foodcritic/rules/*_/_.rb and add these to the
  list of files loaded by the RuleDsl.
