### PR TITLE
Include docs and LICENSE in the gem

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.add_dependency('treetop', '~> 1.4.10')
   s.add_dependency('yajl-ruby', '~> 1.1.0')
   s.add_dependency('erubis')
-  s.files = Dir['chef_dsl_metadata/*.json'] + Dir['lib/**/*.rb'] + Dir['*.md'] + Dir['LICENSE']
+  s.files = Dir['chef_dsl_metadata/*.json'] + Dir['lib/**/*.rb']
+  s.files += Dir['spec/**/*'] + Dir['features/**/*']
+  s.files += Dir['*.md'] + Dir['LICENSE']
   s.required_ruby_version = '>= 1.9.2'
 end


### PR DESCRIPTION
Hi, I just started looking at packaging foodcritic [for Debian](http://bugs.debian.org/711220) and the first order of business is to make sure that the licensing is sane.

Can we please include LICENSE in the gem. Right now, there is only a reference to the MIT license in the `metadata.yml`, but no actual license statement...

Other documentation is also a nice-to-have. If there are unit-tests that can be run at package build time, we should probably also include those, but I haven't looked into that yet.

I'm fairly new to Ruby and have no experience in packaging it, so hope this is all sane...
