### PR TITLE
Since Cygwin doesn't have a built-in rake, foodcritic should depend on the rake gem.

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency('treetop', '~> 1.4.10')
   s.add_dependency('yajl-ruby', '~> 1.1.0')
   s.add_dependency('erubis')
-  s.add_dependency('rake')
+  s.add_dependency('rake', '~> 10.1.0')
   s.files = Dir['chef_dsl_metadata/*.json'] + Dir['lib/**/*.rb']
   s.files += Dir['spec/**/*'] + Dir['features/**/*']
   s.files += Dir['*.md'] + Dir['LICENSE'] + Dir['man/*']


### PR DESCRIPTION
On Cygwin using `thor-foodcritic` setup from `berkshelf`, I found that `thor list` was failing because it couldn't find `rake` in the bundle:

```
[dthrift@RS082:marker]$ thor list --debug
WARNING: unable to load thorfile "/home/dthrift/cookbooks/marker/Thorfile": cannot load such file -- rake
/usr/lib/ruby/gems/1.9.1/gems/polyglot-0.3.3/lib/polyglot.rb:63:in `require'
/usr/lib/ruby/gems/1.9.1/gems/polyglot-0.3.3/lib/polyglot.rb:63:in `require'
/usr/lib/ruby/gems/1.9.1/bundler/gems/foodcritic-f6eb84ec6bbc/lib/foodcritic/rake_task.rb:1:in `<top (required)>'
/usr/lib/ruby/gems/1.9.1/bundler/gems/foodcritic-f6eb84ec6bbc/lib/foodcritic.rb:19:in `require_relative'
/usr/lib/ruby/gems/1.9.1/bundler/gems/foodcritic-f6eb84ec6bbc/lib/foodcritic.rb:19:in `<top (required)>'
/usr/lib/ruby/gems/1.9.1/gems/thor-foodcritic-0.2.0/lib/thor-foodcritic.rb:2:in `require'
/usr/lib/ruby/gems/1.9.1/gems/thor-foodcritic-0.2.0/lib/thor-foodcritic.rb:2:in `<top (required)>'
/usr/lib/ruby/gems/1.9.1/gems/thor-foodcritic-0.2.0/lib/thor/foodcritic.rb:1:in `require'
/usr/lib/ruby/gems/1.9.1/gems/thor-foodcritic-0.2.0/lib/thor/foodcritic.rb:1:in `<top (required)>'
/home/dthrift/cookbooks/marker/Thorfile:5:in `require'
/home/dthrift/cookbooks/marker/Thorfile:5:in `load_thorfile'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/util.rb:157:in `class_eval'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/util.rb:157:in `load_thorfile'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/runner.rb:214:in `block in initialize_thorfiles'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/runner.rb:213:in `each'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/runner.rb:213:in `initialize_thorfiles'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/runner.rb:156:in `list'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
/usr/lib/ruby/gems/1.9.1/gems/thor-0.18.1/bin/thor:6:in `<top (required)>'
/usr/bin/thor:23:in `load'
/usr/bin/thor:23:in `<main>'
No Thor commands available
```

It looks like Cygwin doesn't ship `rake` as part of the base ruby, but instead only as a gem.
