### PR TITLE
Strip whitespace from depends

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -108,7 +108,7 @@ module FoodCritic
       #       depends cbk
       #     end
       deps = deps.to_a + word_list_values(ast, "//command[ident/@value='depends']")
-      deps.map{|dep| dep['value']}
+      deps.map{|dep| dep['value'].strip }
     end
 
     # The key / value pair in an environment or role ruby file


### PR DESCRIPTION
This was flagging our cookbooks incorrectly for FC007 due to the way we
specify long list of dependencies.

``` ruby
%w[
  apt
  build-essential
  git
  python
  ark
  runit
  firewall
].each do |dep|
  depends dep
end
```

Having the names indented means they're actually strings like "  apt"
which is how the ast sees them.

```
  [0] <tstring_content value="  apt">
  <pos line="9" column="0"/>
```

The leading space doesn't actually matter though since knife strips the
whitespace when it's building metadata.json.

The correct place to fix this is probably in the AST but I think that's
way outside my skillset.
