### PR TITLE
Adding workaround for libxml2-2.6.26 xpath dup issue

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -110,7 +110,7 @@ module FoodCritic
       #       depends cbk
       #     end
       deps = deps.to_a + word_list_values(ast, "//command[ident/@value='depends']")
-      deps.map{|dep| dep['value'].strip }
+      deps.uniq.map{|dep| dep['value'].strip }
     end
 
     # The key / value pair in an environment or role ruby file


### PR DESCRIPTION
Nokogiri wraps libxml2, which on some old versions (noticed on 2.6.26 on CentOS 5) has a bug causing xpath queries to return duplicate elements under some circumstances.

see https://github.com/sparklemotion/nokogiri/issues/246

This caused api_spec to fail, so fixed by removing duplicate elements from array before extracting the values
