### PR TITLE
Update dsl, add RuleDsl#update

### DIFF
--- a/lib/foodcritic/dsl.rb
+++ b/lib/foodcritic/dsl.rb
@@ -34,7 +34,14 @@ module FoodCritic
     # Define a new rule, the outer block of a rule definition.
     def rule(code, name, &block)
       @rules = [] if @rules.nil?
-      @rules << Rule.new(code, name)
+      @rule = Rule.new(code, name)
+      @rules << @rule
+      yield self
+    end
+
+    # update a rule
+    def update(code, &block)
+      @rule = rules.find {|rule| rule.code == code }
       yield self
     end
 
@@ -52,7 +59,7 @@ module FoodCritic
 
     def self.rule_block(name)
       define_method(name) do |&block|
-        rules.last.send("#{name}=".to_sym, block)
+        @rule.send("#{name}=".to_sym, block)
       end
     end
 


### PR DESCRIPTION
It would be helpful to be able to update an existing foodcritic rule, either to change the behavior or to whitelist one of the checks. 

```ruby
update "FC041" do
  recipe do |ast|
  end
end
```

