### PR TITLE
iterate through all the cmd blocks of a recipe instead of stopping at the first block

### DIFF
--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -573,7 +573,7 @@ rule "FC040", "Execute resource used to run git commands" do
       cmd_str = (resource_attribute(cmd, 'command') || resource_name(cmd)).to_s
 
       git_cmd = cmd_str.match(/git ([a-z]+)/)
-      break false if git_cmd.nil?
+      next if git_cmd.nil?
 
       !git_cmd.captures.nil? && possible_git_commands.include?(git_cmd.captures[0])
     end


### PR DESCRIPTION
This is a fix for [issue 186](https://github.com/acrmp/foodcritic/issues/186)
