### PR TITLE
Relax yajl-ruby dependency

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', '~> 1.5.4')
   s.add_dependency('rake')
   s.add_dependency('treetop', '~> 1.4.10')
-  s.add_dependency('yajl-ruby', '~> 1.1.0')
+  s.add_dependency('yajl-ruby', '~> 1.1')
   s.add_dependency('erubis')
   s.files = Dir['chef_dsl_metadata/*.json'] + Dir['lib/**/*.rb']
   s.files += Dir['spec/**/*'] + Dir['features/**/*']


### PR DESCRIPTION
I'm currently unable to satisfy this dependencies:

```
Bundler could not find compatible versions for gem "yajl-ruby":
  In Gemfile:
    foodcritic (>= 3.0.3) ruby depends on
      yajl-ruby (~> 1.1.0) ruby

    yajl-ruby (1.2.0)
```
