### PR TITLE
Cache results of read_ast call

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency('treetop', '~> 1.4.10')
   s.add_dependency('yajl-ruby', '~> 1.1.0')
   s.add_dependency('erubis')
+  s.add_dependency('rufus-lru', '~> 1.0.5')
   s.files = Dir['chef_dsl_metadata/*.json'] + Dir['lib/**/*.rb']
   s.files += Dir['spec/**/*'] + Dir['features/**/*']
   s.files += Dir['*.md'] + Dir['LICENSE'] + Dir['man/*']

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'rufus-lru'
 
 module FoodCritic
 
@@ -212,10 +213,12 @@ module FoodCritic
 
     # Read the AST for the given Ruby source file
     def read_ast(file)
-      @ast_cache ||= Hash.new do |h,k|
-        h[k] = uncached_read_ast(k)
+      @ast_cache ||= Rufus::Lru::Hash.new(5)
+      if @ast_cache.include?(file)
+        @ast_cache[file]
+      else
+        @ast_cache[file] = uncached_read_ast(file)
       end
-      @ast_cache[file]
     end
 
     # Retrieve a single-valued attribute from the specified resource.


### PR DESCRIPTION
In order to speed up linting a project, we can cache the results of read_ast between calls. In a real world repo that reads over 800 files, that change more than halves the time (50s vs 2:15).

The test suite also gets a nice boost as a result.
