### PR TITLE
The rake task needs to require foodcritic.

### DIFF
--- a/lib/foodcritic/rake_task.rb
+++ b/lib/foodcritic/rake_task.rb
@@ -1,5 +1,6 @@
 require 'rake'
 require 'rake/tasklib'
+require 'foodcritic'
 
 module FoodCritic
   module Rake


### PR DESCRIPTION
This makes using the LintTask easier:

```
require 'foodcritic/rake_task'

FoodCritic::Rake::LintTask.new
```