### PR TITLE
Rake task can use context output

### DIFF
--- a/features/build_framework_support.feature
+++ b/features/build_framework_support.feature
@@ -67,6 +67,16 @@ I want to be able to invoke the lint tool from my build
     | style              | {:fail_tags => ['correctness,style']}        | fail          | FC002       |
     | style,correctness  | {:fail_tags => [], :tags => ['correctness']} | succeed       | FC006       |
 
+  @context
+  Scenario: Specify that contexts should be shown
+    Given a cookbook with a single recipe that reads node attributes via symbols,strings
+      And the cookbook has a Gemfile that includes rake and foodcritic
+      And a Rakefile that defines a lint task with a block setting options to {:context => true}
+      When I run the build
+      Then the recipe filename should be displayed
+      And the attribute consistency warning 019 should be displayed below
+      And the line number and line of code that triggered the warning should be displayed
+
   Scenario Outline: Specify paths to lint
     Given a cookbook that has <problems> problems
       And the cookbook has a Gemfile that includes rake and foodcritic

--- a/lib/foodcritic/rake_task.rb
+++ b/lib/foodcritic/rake_task.rb
@@ -18,7 +18,8 @@ module FoodCritic
       def options
         {:fail_tags => ['correctness'], # differs to default cmd-line behaviour
          :cookbook_paths => @files,
-         :exclude_paths => ['test/**/*', 'spec/**/*', 'features/**/*']
+         :exclude_paths => ['test/**/*', 'spec/**/*', 'features/**/*'],
+         :context => false,
         }.merge(@options)
       end
 
@@ -26,9 +27,9 @@ module FoodCritic
         desc "Lint Chef cookbooks"
         task(name) do
           result = FoodCritic::Linter.new.check(options)
-          if result.warnings.any?
-            puts result
-          end
+          printer = options[:context] ? ContextOutput.new : SummaryOutput.new
+
+          printer.output(result) if result.warnings.any?
 
           fail result.to_s if result.failed?
         end


### PR DESCRIPTION
Add support for ContextOutput and SummaryOutput to the rake LintTask.

It can be enabled with the option `:context` set to `true`.
