### PR TITLE
Add task for build_features (aruba features)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,14 @@ Cucumber::Rake::Task.new(:features) do |t|
   t.cucumber_opts += ['features']
 end
 
+desc 'Run Cucumber build features via Aruba'
+Cucumber::Rake::Task.new(:build_features) do |t|
+  t.cucumber_opts = ['-f', 'progress', '--strict']
+  ENV['FC_FORK_PROCESS'] = true.to_s
+  t.cucumber_opts += ['-t', '@build,@context']
+  t.cucumber_opts += ['features']
+end
+
 desc 'Run RuboCop'
 RuboCop::RakeTask.new(:rubocop) do |task|
   task.patterns = ['bin/*']

--- a/Rakefile
+++ b/Rakefile
@@ -35,6 +35,6 @@ RuboCop::RakeTask.new(:rubocop) do |task|
 end
 
 desc 'Build the manpage'
-task :man do
+task(:man) do
   sh 'ronn -w --roff man/*.ronn'
 end


### PR DESCRIPTION
Add a task to run the build_features (@build and @context).

It took me a while to figure out how to run those so I could create
the test(s) for #204.

It may be worthwhile adding these to the default task as well.
