### PR TITLE
gitignore: .bundle and tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tmp
 Gemfile.lock
 .DS_Store
 .rvmrc
+/.bundle/
+/tags


### PR DESCRIPTION
- `.bundle` -- useful to ignore in case `bundler` is passed options.
- `tags` -- ctags is a great way to search source, ruby included.
