### PR TITLE
Add command line support for exclude_paths

### DIFF
--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -13,6 +13,7 @@ module FoodCritic
         :fail_tags => [],
         :tags => [],
         :include_rules => [],
+        :exclude_paths => [],
         :cookbook_paths => [],
         :role_paths => [],
         :environment_paths => []
@@ -42,6 +43,10 @@ module FoodCritic
         opts.on("-E", "--environment-path PATH",
           "Environment path(s) to check.") do |e|
           @options[:environment_paths] << e
+        end
+        opts.on("-X", "--exclude PATH",
+          "Exclude path(s) from being checked.") do |e|
+          @options[:exclude_paths] << e
         end
         opts.on("-I", "--include PATH",
           "Additional rule file path(s) to load.") do |i|


### PR DESCRIPTION
This adds an option for excluding paths:

```
-X, --exclude PATH               Exclude path(s) from being checked.
```

It uses the `:exclude_paths` option in `Linter`
