### PR TITLE
Implement exclusion of tags

### DIFF
--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -16,7 +16,8 @@ module FoodCritic
         :cookbook_paths => [],
         :role_paths => [],
         :environment_paths => [],
-        :exclude_paths => []
+        :exclude_paths => [],
+        :exclude_tags => []
       }
       @parser = OptionParser.new do |opts|
         opts.banner = 'foodcritic [cookbook_paths]'
@@ -67,6 +68,10 @@ module FoodCritic
         opts.on("-X", "--exclude PATH",
           "Exclude path(s) from being linted.") do |e|
           options[:exclude_paths] << e
+        end
+        opts.on("-x", "--exclude-tags TAGS",
+          "Exclude tag(s) from being matched.") do |x|
+          @options[:exclude_tags] << x
         end
       end
       # -v is not implemented but OptionParser gives the Foodcritic's version

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -43,6 +43,7 @@ module FoodCritic
     # * `:tags` - The tags to filter rules based on
     # * `:fail_tags` - The tags to fail the build on
     # * `:exclude_paths` - Paths to exclude from linting
+    # * `:exclude_tags` - Tags to exclude from matching
     #
     def check(options = {})
 
@@ -63,7 +64,7 @@ module FoodCritic
           cookbook_tags(p[:filename])
         end
 
-        active_rules(relevant_tags).each do |rule|
+        active_rules(relevant_tags, options[:exclude_tags]).each do |rule|
 
           state = {
             :path_type => p[:path_type],
@@ -174,10 +175,13 @@ module FoodCritic
       tags
     end
 
-    def active_rules(tags)
+    def active_rules(tags, excluded_tags)
       @rules.select do |rule|
         rule.matches_tags?(tags) and
         applies_to_version?(rule, chef_version)
+      end
+      @rules.reject do |rule|
+        rule.matches_tags?(excluded_tags)
       end
     end
 


### PR DESCRIPTION
Hi there,

Thank you for foodcritic!

We ran into a situation with our twemproxy cookbook where a rule was triggered for wrong reasons:

``` ruby
# assuming you perform a Chef search and store it in a variable `nodes`

nodes.each do |node|
      twemproxy_pools ||= {}
      twemproxy_pools[pool] ||= {}
      twemproxy_pools[pool]['twemproxy_port'] = twemproxy_port
      twemproxy_pools[pool]['redis_port'] ||= []
      twemproxy_pools[pool]['redis_port'] << node['pool_info'].grep(/redis.pools.#{env}.#{pool}.\d+/).map { |tag| tag.match(/redis.pools.#{env}.#{pool}.(\d+)/)[1] }[0]
      twemproxy_pools[pool]['nodes'] ||= {}
      twemproxy_pools[pool]['nodes'][node['name']] ||= {}
      twemproxy_pools[pool]['nodes'][node['name']]['ip'] ||= node['ip']
    end
```

In this case, `twemproxy_pools[pool]['nodes'][node['name']]` will trigger `FC039` even though it's "fine" (just shadowing).

Instead of specifying every rule that exists without `FC039`, I wanted a quick way to just exclude one or many, hence this PR.

Let me know if you're open to it and I'll try to write a feature for it.

Thanks for looking into it!
