### PR TITLE
increase default dsl_metadata to chef v. 11.6.0

### DIFF
--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -11,7 +11,7 @@ module FoodCritic
 
     # The default version that will be used to determine relevant rules. This
     # can be over-ridden at the command line with the `--chef-version` option.
-    DEFAULT_CHEF_VERSION = "11.4.0"
+    DEFAULT_CHEF_VERSION = "11.6.0"
     attr_reader :chef_version
 
     # Perform a lint check. This method is intended for use by the command-line


### PR DESCRIPTION
The default chef version is currently 11.4.0, yet the latest dsl_metadata available is 11.6.0.