### PR TITLE
relax nokogiri gemspec pinning

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -10,13 +10,13 @@ Gem::Specification.new do |s|
   s.homepage = 'http://foodcritic.io'
   s.license = 'MIT'
   s.executables << 'foodcritic'
-  s.add_dependency('gherkin', '~> 2.11.7')
+  s.add_dependency('gherkin', '~> 2.11')
   s.add_dependency('nokogiri', '~> 1.5')
   s.add_dependency('rake')
-  s.add_dependency('treetop', '~> 1.4.10')
+  s.add_dependency('treetop', '~> 1.4')
   s.add_dependency('yajl-ruby', '~> 1.1')
   s.add_dependency('erubis')
-  s.add_dependency('rufus-lru', '~> 1.0.5')
+  s.add_dependency('rufus-lru', '~> 1.0')
   s.files = Dir['chef_dsl_metadata/*.json'] + Dir['lib/**/*.rb']
   s.files += Dir['spec/**/*'] + Dir['features/**/*']
   s.files += Dir['*.md'] + Dir['LICENSE'] + Dir['man/*']


### PR DESCRIPTION
pins the major version of nokogiri rather than major.minor so that it will pick up 1.6.1

second commit also adds the same for the rest of the gems -- nokogiri is the one that is immediately causing me pain, so since cherry picking 3b9ba66 would solve my problems i split up the commits.
