### PR TITLE
Relax nokogiri gemspec pinning

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.executables << 'foodcritic'
   s.add_dependency('gherkin', '~> 2.11.7')
-  s.add_dependency('nokogiri', '~> 1.5.4')
+  s.add_dependency('nokogiri', '~> 1.6')
   s.add_dependency('rake')
   s.add_dependency('treetop', '~> 1.4.10')
   s.add_dependency('yajl-ruby', '~> 1.1')


### PR DESCRIPTION
Dependencies conflicts with knife-ec2:

```
Bundler could not find compatible versions for gem "nokogiri":
  In Gemfile:
    foodcritic (= 3.0.3) ruby depends on
      nokogiri (~> 1.5.4) ruby

    knife-ec2 (= 0.8.0) ruby depends on
      nokogiri (1.6.1)
```