### PR TITLE
FC047 triggers when override! and default! are used

### DIFF
--- a/features/047_check_for_attribute_assignment_without_precedence.feature
+++ b/features/047_check_for_attribute_assignment_without_precedence.feature
@@ -21,8 +21,10 @@ Feature: Check for attribute assignment without specified precedence
     | node.normal['foo'] = 'bar'          | should not   |
     | node.default['foo'] = 'bar'         | should not   |
     | node.force_default['foo'] = 'bar'   | should not   |
+    | node.default!['foo'] = 'bar'        | should not   |
     | node.set['foo'] = 'bar'             | should not   |
     | node.override['foo'] = 'bar'        | should not   |
+    | node.override!['foo'] = 'bar'       | should not   |
     | node.force_override['foo'] = 'bar'  | should not   |
     | node.automatic_attrs['foo'] = 'bar' | should not   |
     | node['foos'] << 'bar'               | should       |

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -463,6 +463,7 @@ module FoodCritic
           %w{
             automatic_attrs
             default
+            default!
             default_unless
             force_default
             force_override
@@ -470,6 +471,7 @@ module FoodCritic
             normal
             normal_unless
             override
+            override!
             override_unless
             set
             set_unless


### PR DESCRIPTION
When using short version for attribute precedence level (default! and override!) FC047 is triggered, 
it shouldn't because is valid chef and ruby code often suggested by linter tool
