### PR TITLE
FC007: accept 'suggests' and 'recommends'

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -97,14 +97,14 @@ module FoodCritic
       File.basename(file)
     end
 
-    # The dependencies declared in cookbook metadata.
+    # The dependencies, recommendations and suggestions declared in cookbook metadata.
     def declared_dependencies(ast)
       raise_unless_xpath!(ast)
 
       # String literals.
       #
       #     depends 'foo'
-      deps = ast.xpath(%q{//command[ident/@value='depends']/
+      deps = ast.xpath(%q{//command[ident/@value='depends' or ident/@value='recommends' or ident/@value='suggests']/
         descendant::args_add/descendant::tstring_content[1]})
 
       # Quoted word arrays are also common.
@@ -113,7 +113,7 @@ module FoodCritic
       #       depends cbk
       #     end
       deps = deps.to_a +
-        word_list_values(ast, "//command[ident/@value='depends']")
+        word_list_values(ast, "//command[ident/@value='depends' or ident/@value='recommends' or ident/@value='suggests']/")
       deps.uniq.map { |dep| dep['value'].strip }
     end
 


### PR DESCRIPTION
Chef supports the `suggests` and `recommends` as keywords for soft dependencies. They are a NOOP and the semantics are a bit [unclear](http://tickets.opscode.com/browse/CHEF-3870) but they're [used](socrata-cookbooks/java@90ecd3db) for "most people don't need this" dependencies, e.g. depending on the `windows` cookbook.

Fixes acrmp/foodcritic#159.