### PR TITLE
make the --epic-fail option take special 'all' value

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ Cucumber::Rake::Task.new(:features) do |t|
 end
 
 desc 'Run RuboCop'
-Rubocop::RakeTask.new(:rubocop) do |task|
+RuboCop::RakeTask.new(:rubocop) do |task|
   task.patterns = ['bin/*']
   task.patterns = ['lib/**/*.rb']
 end

--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -253,13 +253,13 @@ module FoodCritic
     # Assert that warnings have not been raised against the test code which
     # should have been excluded from linting.
     def assert_no_test_warnings
-      has_test_warnings?(@review).should be_false
+      has_test_warnings?(@review).should be_falsey
     end
 
     # Assert that warnings have been raised against the test code which
     # shouldn't have been excluded from linting.
     def assert_test_warnings
-      has_test_warnings?(@review).should be_true
+      has_test_warnings?(@review).should be_truthy
     end
 
     # Run a lint check with the provided command line arguments.

--- a/lib/foodcritic/domain.rb
+++ b/lib/foodcritic/domain.rb
@@ -14,6 +14,8 @@ module FoodCritic
       @rule, @match = rule, match
       @is_failed = if options[:fail_tags].empty?
                      false
+                   elsif options[:fail_tags] == ["all"]
+                     true
                    else
                      rule.matches_tags?(options[:fail_tags])
                    end


### PR DESCRIPTION
Adds the ability for the --epic-fail option to take 'all' value. It will make all rules 'epic fail' when they fail.