### PR TITLE
Show progress with --progress

### DIFF
--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -55,6 +55,10 @@ module FoodCritic
                 'foodcritic/rules/**/*.rb') do |g|
           @options[:search_gems] = true
         end
+        opts.on("-P", "--progress",
+                "Show progress of files being checked") do
+          @options[:progress] = true
+        end
         opts.on('-R', '--role-path PATH',
                 'Role path(s) to check.') do |r|
           @options[:role_paths] << r


### PR DESCRIPTION
```
$ foodcritic . --progress
Food Critic
Checking 15 files
xx.x...........
FC001: Use strings in preference to symbols to access node attributes: ./attributes/default.rb:37
FC019: Access node attributes in a consistent manner: ./attributes/default.rb:37
FC028: Incorrect #platform? usage: ./recipes/default.rb:27
```

I wanted this because I run foodcritic in addition to other tools in sequence, and it's weird to see progress output from others but not foodcritic.

There are also feature specs at https://github.com/justincampbell/foodcritic/compare/progress-output-features, but I couldn't seem to get them working.