### PR TITLE
Fix for issue #265.

### DIFF
--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -219,7 +219,7 @@ module FoodCritic
           if File.directory?(dir)
             glob = if path_type == :cookbook
                      '{metadata.rb,{attributes,definitions,libraries,'\
-                     'providers,recipes,resources}/*.rb,templates/*/*.erb}'
+                     'providers,recipes,resources}/*.rb,templates/**/*.erb}'
                    else
                      '*.rb'
                    end


### PR DESCRIPTION
This should find all *.erb files throughout the folder tree under templates.