### PR TITLE
Added default locations for additional rules files

### DIFF
--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -126,6 +126,12 @@ module FoodCritic
       rule_files = [File.join(File.dirname(__FILE__), 'rules.rb')]
       rule_files << options[:include_rules]
       rule_files << rule_files_in_gems if options[:search_gems]
+      rl_file = Pathname.new('~/.chef/foodcritic/rules.rb').expand_path
+      rule_files << rl_file.to_s if rl_file.exist?
+      rl_dir = Pathname.new('~/.chef/foodcritic/rules').expand_path
+      rule_files << rl_dir.to_s if rl_dir.exist? && rl_dir.directory?
+      ### Would like to include config directory under chef repo, but not sure how to correctly reference it.
+      #Pathname.new( cookbook_dir(file)).parent.parent + "/config/foodcritic/rules"
       @rules = RuleDsl.load(rule_files.flatten.compact, chef_version)
     end
 


### PR DESCRIPTION
Two additions to make inclusion of custom / extra rules easier.  Searches the following locations for rules.
- ~/.chef/foodcritic/rules.rb
- ~/.chef/foodcritic/rules/*.rb

I would also like to add rules from the <chef_repo>/config directory, but could not find a good way to reference the chef repo directory from within load_rules!.  This would make enforcing the same rules across a group of users easier, as ~/.chef is probably not shared, but <chef_repo>/config probably is.

Looking at this, along with my other pull request (#229 update linter.rb (horribly named, sorry)), I'm wondering what your thoughts are on creating a base config file / directory that could be customized with standard options and locations to load additional rule & tag files.  We use foodcritic on every cookbook, but find ourselves using the same command line options every time (-I <include our rules>, -X <exclude paths>, and occasionally --context)

Unless I'm blind and missing something, there isn't a way to set these permanently, so we can avoid the long command line each time (perhaps this should be a separate issue).

Thanks