### PR TITLE
tests: make simplecov optional

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,10 @@
-require 'simplecov'
-SimpleCov.start do
-  add_filter '/features/'
+begin
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter '/features/'
+  end
+rescue LoadError
+  warn 'warning: simplecov gem not found; skipping coverage'
 end
 
 require 'aruba/cucumber'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
-require 'simplecov'
-SimpleCov.start do
-  add_filter '/spec/'
+begin
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter '/spec/'
+  end
+rescue LoadError
+  warn 'warning: simplecov gem not found; skipping coverage'
 end
 
 require 'minitest/autorun'


### PR DESCRIPTION
If we do not have SimpleCov installed, we should be able to continue with the rest of the test suite.

This allows the tests to run outside of Bundler if SimpleCov is not installed.