### PR TITLE
FC054, Name should match cookbook dir name in metadata

### DIFF
--- a/features/054_name_should_match_cookbook_dir_name_in_metadata.feature
+++ b/features/054_name_should_match_cookbook_dir_name_in_metadata.feature
@@ -1,0 +1,15 @@
+Feature: Name should match cookbook dir name in metadata
+
+  In order to avoid complications where a cookbook repository name differs from the cookbook name
+  As a developer
+  I want to set the cookbook name within the metadata
+
+  Scenario: Name mismatched in metadata
+    Given a cookbook with metadata that includes a mismatched cookbook name
+     When I check the cookbook
+     Then the name should match cookbook dir name warning 054 should be displayed against the metadata file
+
+  Scenario: Name mismatched in metadata
+    Given a cookbook with metadata that includes a matched cookbook name
+     When I check the cookbook
+     Then the name should match cookbook dir name warning 054 should not be displayed against the metadata file

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -1321,6 +1321,15 @@ Given /^a cookbook with metadata that (includes|does not include) a suggests key
   }
 end
 
+Given /^a cookbook with metadata that includes a (matched|mismatched) cookbook name$/ do |match|
+  write_metadata %Q{
+    name 'example'
+  } if match == 'matched'
+  write_metadata %Q{
+    name 'bogart'
+  } if match == 'mismatched'
+end
+
 Given /^a directory that contains a role file ([^ ]+) in (json|ruby) that defines role name (.*)$/ do |file_name, format, role_name|
   role(:role_name => %Q{"#{role_name}"}, :file_name => file_name, :format => format.to_sym)
 end

--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -64,6 +64,7 @@ module FoodCritic
       'FC051' => 'Template partials loop indefinitely',
       'FC052' => 'Metadata uses the unimplemented "suggests" keyword',
       'FC053' => 'Metadata uses the unimplemented "recommends" keyword',
+      'FC054' => 'Name should match cookbook dir name in metadata',
       'FCTEST001' => 'Test Rule'
     }
 

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -769,3 +769,13 @@ rule 'FC053', 'Metadata uses the unimplemented "recommends" keyword' do
     ast.xpath(%Q(//command[ident/@value='recommends']))
   end
 end
+
+rule 'FC054', 'Name should match cookbook dir name in metadata' do
+  tags %w(annoyances metadata)
+  applies_to { |version| version >= gem_version('12.0.0') }
+  metadata do |ast, filename|
+    unless cookbook_name(filename) == filename.split(File::SEPARATOR)[-2]
+      [file_match(filename)]
+    end
+  end
+end


### PR DESCRIPTION
In Chef 12 name metadata attribute needs to match cookbook dir name. This commit makes FC045 more strict, by not only requiring name to be present, but also match.

While this might break back compat, it actually enforces what new releases require, so I guess it's ok. Spawning a new rule just for this seemed like too much.

Closes https://github.com/acrmp/foodcritic/issues/242