### PR TITLE
Handle flagging binary files properly

### DIFF
--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -152,6 +152,8 @@ module FoodCritic
       else
         false
       end
+    rescue
+      false
     end
 
     # Some rules are version specific.


### PR DESCRIPTION
Flagging offending paths with `file_match` blows up for binary files.
