### PR TITLE
Upgrade nokogiri dependency to support traveling-ruby nokogiri 1.6.5

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.executables << 'foodcritic'
   s.add_dependency('gherkin', '~> 2.11')
-  s.add_dependency('nokogiri', '~> 1.5')
+  s.add_dependency('nokogiri', '>= 1.5', '< 2.0')
   s.add_dependency('rake')
   s.add_dependency('treetop', '~> 1.4')
   s.add_dependency('yajl-ruby', '~> 1.1')


### PR DESCRIPTION
The available pre-built native C gems for traveling-ruby include only nokogiri 1.6.5. Can you please support 1.6.5?

This patch will continue to support 1.5 + also 1.6.5. It caps the support at anything before 2.0 version in future.
