### PR TITLE
Ensure metadata specifies maintainer and maintainer_email

### DIFF
--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -62,6 +62,8 @@ module FoodCritic
       'FC049' => 'Role name does not match containing file name',
       'FC050' => 'Name includes invalid characters',
       'FC051' => 'Template partials loop indefinitely',
+      'FC052' => 'Ensure maintainer is set in metadata',
+      'FC053' => 'Ensure maintainer_email is set in metadata',
       'FCTEST001' => 'Test Rule'
     }
 

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -755,3 +755,31 @@ rule 'FC051', 'Template partials loop indefinitely' do
     end.map { |t| file_match(t) }
   end
 end
+
+rule 'FC052', 'Ensure maintainer is set in metadata' do
+  tags %w(correctness metadata)
+  metadata do |ast, filename|
+    unless ast.xpath('descendant::stmts_add/command/ident/@value="maintainer"')
+      [file_match(filename)]
+    end
+  end
+  cookbook do |filename|
+    if !File.exist?(File.join(filename, 'metadata.rb'))
+      [file_match(File.join(filename, 'metadata.rb'))]
+    end
+  end
+end
+
+rule 'FC053', 'Ensure maintainer_email is set in metadata' do
+  tags %w(correctness metadata)
+  metadata do |ast, filename|
+    unless ast.xpath('descendant::stmts_add/command/ident/@value="maintainer_email"')
+      [file_match(filename)]
+    end
+  end
+  cookbook do |filename|
+    if !File.exist?(File.join(filename, 'metadata.rb'))
+      [file_match(File.join(filename, 'metadata.rb'))]
+    end
+  end
+end


### PR DESCRIPTION
Adds two new rules

* FC052 => Ensure maintainer is set in metadata
* FC053 => Ensure maintainer_email is set in metadata

See also [https://github.com/chef/chef-manage-issues/issues/20](https://github.com/chef/chef-manage-issues/issues/20)