### PR TITLE
Update rules.rb

### DIFF
--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -618,7 +618,7 @@ rule 'FC041', 'Execute resource used to run curl or wget commands' do
   recipe do |ast|
     find_resources(ast, type: 'execute').select do |cmd|
       cmd_str = (resource_attribute(cmd, 'command') || resource_name(cmd)).to_s
-      (cmd_str.include?('curl ') || cmd_str.include?('wget '))
+      (cmd_str.include?('wget '))
     end
   end
 end


### PR DESCRIPTION
According to the man pages of wget: 
       Wget - The non-interactive network downloader.
This indeed is a downloader which should be constrained in a remote_file resource. 
However , 
According to the man pages of curl: 
curl is a tool to transfer data from or to a server, using one of the supported protocols
It nowhere explicitly is used as a downloader. 
It should be removed by definition from this rule. 
We could amend it by checking for curl  -o/--output <file>
This has been pointed out in : 
https://github.com/acrmp/foodcritic/issues/240
I would like to change this across food critic with a pull request. Please reply if you think that's acceptable