### PR TITLE
add warnings for use of recommends/suggests

### DIFF
--- a/features/052_check_for_metadata_using_suggests_keyword.feature
+++ b/features/052_check_for_metadata_using_suggests_keyword.feature
@@ -1,0 +1,15 @@
+Feature: Check for metadata using suggests keyword
+
+  In order to ensure that recipe metadata is stable
+  As a developer
+  I want to identify metadata that is using unimplemented features whose definitions may change in the future
+
+  Scenario: Metadata with the suggests keyword
+    Given a cookbook with metadata that includes a suggests keyword
+     When I check the cookbook
+     Then the metadata using suggests warning 052 should be shown against the metadata file
+
+  Scenario: Metadata without the suggests keyword
+    Given a cookbook with metadata that does not include a suggests keyword
+     When I check the cookbook
+     Then the metadata using suggests warning 052 should be not shown against the metadata file

--- a/features/053_check_for_metadata_using_recommends_keyword.feature
+++ b/features/053_check_for_metadata_using_recommends_keyword.feature
@@ -1,0 +1,15 @@
+Feature: Check for metadata using recommends keyword
+
+  In order to ensure that recipe metadata is stable
+  As a developer
+  I want to identify metadata that is using unimplemented features whose definitions may change in the future
+
+  Scenario: Metadata with the recommends keyword
+    Given a cookbook with metadata that includes a recommends keyword
+     When I check the cookbook
+     Then the metadata using recommends warning 053 should be shown against the metadata file
+
+  Scenario: Metadata without the recommends keyword
+    Given a cookbook with metadata that does not include a recommends keyword
+     When I check the cookbook
+     Then the metadata using recommends warning 053 should be not shown against the metadata file

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -1299,6 +1299,20 @@ Given /^a cookbook with metadata that (specifies|does not specify) the cookbook 
   }
 end
 
+Given /^a cookbook with metadata that (includes|does not include) a recommends keyword$/ do |includes|
+  write_metadata %Q{
+    depends "bar"
+    #{"recommends 'foo'" if includes == 'includes'}
+  }
+end
+
+Given /^a cookbook with metadata that (includes|does not include) a suggests keyword$/ do |includes|
+  write_metadata %Q{
+    depends "bar"
+    #{"suggests 'foo'" if includes == 'includes'}
+  }
+end
+
 Given /^a directory that contains a role file ([^ ]+) in (json|ruby) that defines role name (.*)$/ do |file_name, format, role_name|
   role(:role_name => %Q{"#{role_name}"}, :file_name => file_name, :format => format.to_sym)
 end
@@ -2272,4 +2286,12 @@ Given(/^a cookbook with an? (.*) file with an interpolated name$/) do |file_type
   write_resource "site", content if file_type == "resource"
   write_definition "apache_site", content if file_type == "definition"
   write_library "lib", content if file_type == "library"
+end
+
+Then /^the metadata using suggests warning 052 should be (shown|not shown) against the metadata file$/ do |show_warning|
+  expect_warning('FC052', :file => "metadata.rb", :line => 2, :expect_warning => show_warning == 'shown')
+end
+
+Then /^the metadata using recommends warning 053 should be (shown|not shown) against the metadata file$/ do |show_warning|
+  expect_warning('FC053', :file => "metadata.rb", :line => 2, :expect_warning => show_warning == 'shown')
 end

--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -62,6 +62,8 @@ module FoodCritic
       'FC049' => 'Role name does not match containing file name',
       'FC050' => 'Name includes invalid characters',
       'FC051' => 'Template partials loop indefinitely',
+      'FC052' => 'Metadata uses the unimplemented "suggests" keyword',
+      'FC053' => 'Metadata uses the unimplemented "recommends" keyword',
       'FCTEST001' => 'Test Rule'
     }
 

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -755,3 +755,17 @@ rule 'FC051', 'Template partials loop indefinitely' do
     end.map { |t| file_match(t) }
   end
 end
+
+rule 'FC052', 'Metadata uses the unimplemented "suggests" keyword' do
+  tags %w(style metadata)
+  metadata do |ast, filename|
+    ast.xpath(%Q(//command[ident/@value='suggests']))
+  end
+end
+
+rule 'FC053', 'Metadata uses the unimplemented "recommends" keyword' do
+  tags %w(style metadata)
+  metadata do |ast, filename|
+    ast.xpath(%Q(//command[ident/@value='recommends']))
+  end
+end


### PR DESCRIPTION
These are unimplemented metadata keywords and their use is currently a
sort of no-op.  However, this can cause bugs with different tooling:

https://github.com/berkshelf/berkshelf/issues/1404

It also is likely that whatever the user thinks the semantics should be
eventually that some subset of users will guess incorrectly and get
surprising behavior if we ever do implement these keywords.  The proper
approach to documenting optional cookbooks is currently via text in the
README.md or a comment in the metadata.rb.

The correct course of action in the future is that an RFC should be
submitted to https://github.com/chef/chef-rfc to decide what the suggests
and recommends semantics are, and to actually implement those semantics.
Until then, users should avoid the use of these keywords (essentially
they are 'reserved for future use' -- which means "do not use them now").