### PR TITLE
merge default options before check instead of during intialization

### DIFF
--- a/lib/foodcritic/rake_task.rb
+++ b/lib/foodcritic/rake_task.rb
@@ -4,8 +4,7 @@ require 'rake/tasklib'
 module FoodCritic
   module Rake
     class LintTask < ::Rake::TaskLib
-      attr_accessor :name, :files
-      attr_writer :options
+      attr_accessor :name, :files, :options
 
       def initialize(name = :foodcritic)
         @name = name
@@ -15,23 +14,26 @@ module FoodCritic
         define
       end
 
-      def options
-        {
-          fail_tags: ['correctness'], # differs to default cmd-line behaviour
-          cookbook_paths: @files,
-          exclude_paths: ['test/**/*', 'spec/**/*', 'features/**/*'],
-          context: false,
-        }.merge(@options)
-      end
 
       def define
         desc 'Lint Chef cookbooks' unless ::Rake.application.last_comment
         task(name) do
-          result = FoodCritic::Linter.new.check(options)
+          result = FoodCritic::Linter.new.check(options.merge(default_options))
           printer = options[:context] ? ContextOutput.new : SummaryOutput.new
           printer.output(result) if result.warnings.any?
           abort if result.failed?
         end
+      end
+
+      private
+      def default_options
+        {
+          fail_tags: ['correctness'], # differs to default cmd-line behaviour
+          cookbook_paths: files,
+          exclude_paths: ['test/**/*', 'spec/**/*', 'features/**/*'],
+          context: false,
+          chef_version: FoodCritic::Linter::DEFAULT_CHEF_VERSION
+        }
       end
     end
   end


### PR DESCRIPTION
So that following can work:
```ruby
FoodCritic::Rake::LintTask.new do |t|
  t.options = {
    fail_tags: ['any'],
    cookbook_paths: ['site-cookbooks/', 'cookbooks/'],
    chef_version: Chef::VERSION
  }
end
```