### PR TITLE
Corrects new FC054 if run in current dir

### DIFF
--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -774,7 +774,7 @@ rule 'FC054', 'Name should match cookbook dir name in metadata' do
   tags %w(annoyances metadata)
   applies_to { |version| version >= gem_version('12.0.0') }
   metadata do |ast, filename|
-    unless cookbook_name(filename) == filename.split(File::SEPARATOR)[-2]
+    unless cookbook_name(filename) == File.expand_path(File.dirname(filename)).split(File::SEPARATOR)[-1]
       [file_match(filename)]
     end
   end


### PR DESCRIPTION
When run from within the cookbook directory  "foodcritic .", FC054 was incorrectly trying to match the cookbook name to "." rather than the name of the current directory.