### PR TITLE
Add self-dependency warning

### DIFF
--- a/features/063_cookbook_incorrectly_depends_on_itself.feature
+++ b/features/063_cookbook_incorrectly_depends_on_itself.feature
@@ -1,0 +1,15 @@
+Feature: Check for metadata using suggests keyword
+
+  In order to avoid pathological depsolving issues
+  As a developer
+  I want to identify cookboks that depend on themselves and remove that (unnecessary) dependency
+
+  Scenario: Metadata with self dependency
+    Given a cookbook with metadata that includes a self dependency
+     When I check the cookbook
+     Then the metadata with self dependency warning 063 should be shown against the metadata file
+
+  Scenario: Metadata without self depenency
+    Given a cookbook with metadata that does not include a self dependency
+     When I check the cookbook
+     Then the metadata with self dependency warning 063 should be not shown against the metadata file

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -2461,3 +2461,19 @@ Given 'a cookbook with a metadata version that is a method call' do
     version magic_version_generator('and its args')
   }
 end
+
+Given(/^a cookbook with metadata that (includes|does not include) a self dependency$/) do |includes|
+  write_metadata %Q{
+    name 'bar'
+    depends 'baz'
+    #{"depends 'bar'" if includes == 'includes'}
+  }
+end
+
+Then(/^the metadata with self dependency warning 063 should be (shown|not shown) against the metadata file$/) do |show_warning|
+  if show_warning == 'shown'
+    expect_warning('FC063', :file => "metadata.rb", :line => 3, :expect_warning => true)
+  else
+    expect_warning('FC063', :file => "metadata.rb", :expect_warning => false)
+  end
+end

--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -73,6 +73,7 @@ module FoodCritic
       'FC060' => 'LWRP provider declares use_inline_resources and declares #action_<name> methods',
       'FC061' => 'Valid cookbook versions are of the form x.y or x.y.z',
       'FC062' => 'Cookbook should have version metadata',
+      'FC063' => 'Cookbook incorrectly depends on itself',
       'FCTEST001' => 'Test Rule'
     }
 

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -844,3 +844,12 @@ rule 'FC062', 'Cookbook should have version metadata' do
     [file_match(filename)] unless field(ast, 'version').any?
   end
 end
+
+rule 'FC063', 'Cookbook incorrectly depends on itself' do
+  tags %w(metadata correctness)
+  metadata do |ast, filename|
+    name = cookbook_name(filename)
+    ast.xpath(%Q(//command[ident/@value='depends']/
+              descendant::tstring_content[@value='#{name}']))
+  end
+end


### PR DESCRIPTION
Chef does not require cookbooks to depend on themselves in order to
depsolve.  In addition to this line being useless, it actually creates
problems with depsolving.  The self-dependency can create a circular
dependency where every version of a cookbook will satisfy the circular
dependency on itself which can create a huge mess.

Ideally we need to fix this elsewhere in the ecosystem as well, but
for now this will at least surface the issue to cookbook authors who
use foodcritic.