### PR TITLE
Fix flagging directory symlinks

### DIFF
--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -178,6 +178,7 @@ module FoodCritic
       matches.reject do |m|
         matched_file = m[:filename] || file
         (line = m[:line]) && File.exist?(matched_file) &&
+           !File.directory?(matched_file) &&
            ignore_line_match?(File.readlines(matched_file)[line - 1], rule)
       end
     end


### PR DESCRIPTION
We happen to have an internal rule that discourages symlinks in cookbooks.
This fixes the case of flagging a symlink that is poitning at a directory.