### PR TITLE
let chef gem follow latest 12.x version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :test do
 end
 
 group :development do
-  gem 'chef', '~> 12.1.1'
+  gem 'chef', '~> 12.1'
   gem 'ronn', '~> 0.7'
 
   # We need to lock mustache because ronn does not correctly


### PR DESCRIPTION
use latest 12.x instead of pinning on 12.1.x