### PR TITLE
remove 1.9.3 support

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://foodcritic.io'
   s.license = 'MIT'
   s.executables << 'foodcritic'
+  s.required_ruby_version = ">= 2.0.0"
   s.add_dependency('gherkin', '~> 2.11')
   s.add_dependency('nokogiri', '>= 1.5', '< 2.0')
   s.add_dependency('rake')


### PR DESCRIPTION
we're not testing in travis, so it may break at any time, v4.0.0
is the last foodcritic release that can be guaranteed to support 1.9.3

this will end support for chef-11 users on the omnibus package (which
still ships ruby-1.9.3 for $REASONS).  gem install foodcritic should
still work for those users and pick 4.0.0 over 5.0.0.

if we don't do this, then whenever we really release a version which
breaks 1.9.3 hard then 11 users will pick it up with a gem install and
will be suddenly broken hard instead of just pinned to an old version.