### PR TITLE
catch the CHANGELOG up to v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,30 @@ Features:
 
   - DSL metadata updated for Chef 11.18.x and up to Chef 12.4.1.
   ([related issue](https://github.com/acrmp/foodcritic/issues/362)).
+  - Set default `chef_version` to 12.4.1
+  ([related issue](https://github.com/acrmp/foodcritic/pull/364)).
+  - add warnings for use of recommends/suggests.
+  ([related issue](https://github.com/acrmp/foodcritic/pull/309)).
+  - Show progress with --progress
+  ([related issue](https://github.com/acrmp/foodcritic/pull/244)).
+  - Added -l option to list enabled rules and descriptions
+  ([related issue](https://github.com/acrmp/foodcritic/pull/285)).
+  - Fixed `node.force_default` and `node.force_override` along with many other methods on Chef::Node::Attribute that
+  `Chef::Node#method_missing` was forwarding methods to.
+  ([related issue](https://github.com/acrmp/foodcritic/pull/364)).
+  - FC054, Name should match cookbook dir name in metadata
+  ([related issue](https://github.com/acrmp/foodcritic/pull/282))
+  ([related issue](https://github.com/acrmp/foodcritic/pull/358))
+  ([related issue](https://github.com/acrmp/foodcritic/pull/374)).
 
 Bugfixes:
 
+  - merge default options before check instead of during intialization (in Rake task)
+    ([related issue](https://github.com/acrmp/foodcritic/pull/321)).
+  - Fix UTF-8 errors in template checking
+    ([related issue](https://github.com/acrmp/foodcritic/pull/317)).
+  - Make FC041 smarter about CURL usage
+    ([related issue](https://github.com/acrmp/foodcritic/pull/313)).
   - pinned moustache gem to 0.99 for ruby 1.9.3 compatibility
     Thanks @jdmundrawala
   - Added metadata for missing Chef 11 versions. 
@@ -22,6 +43,10 @@ Bugfixes:
 
 Other:
 
+  - 1.9.3 is removed from the travis matrix and no longer supported
+    ([related issue](https://github.com/acrmp/foodcritic/pull/315)).
+  - 1.9.3 compat is removed from the gemspec (v4.0.0 will be the last version that will install on 1.9.3)
+    ([related issue](https://github.com/acrmp/foodcritic/pull/377)).
   - removed cookbooks no longer present in the chef-cookbooks repo from regression tests
 
 ## 4.0.0 (12th June, 2014)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ Features:
   ([related issue](https://github.com/acrmp/foodcritic/pull/244)).
   - Added -l option to list enabled rules and descriptions
   ([related issue](https://github.com/acrmp/foodcritic/pull/285)).
-  - Fixed `node.force_default` and `node.force_override` along with many other methods on Chef::Node::Attribute that
-  `Chef::Node#method_missing` was forwarding methods to.
-  ([related issue](https://github.com/acrmp/foodcritic/pull/364)).
   - FC054, Name should match cookbook dir name in metadata
   ([related issue](https://github.com/acrmp/foodcritic/pull/282))
   ([related issue](https://github.com/acrmp/foodcritic/pull/358))
@@ -22,6 +19,9 @@ Features:
 
 Bugfixes:
 
+  - Fixed `node.force_default` and `node.force_override` along with many other methods on Chef::Node::Attribute that
+  `Chef::Node#method_missing` was forwarding methods to.
+  ([related issue](https://github.com/acrmp/foodcritic/pull/364)).
   - merge default options before check instead of during intialization (in Rake task)
     ([related issue](https://github.com/acrmp/foodcritic/pull/321)).
   - Fix UTF-8 errors in template checking


### PR DESCRIPTION
all the changelog entries we've missed for the past 6+ months that i could find by surfing through the commit log

several of the administrivia PRs were omitted (.travis.yml tweaks, README.md fixes, etc) that aren't visible to users of the command line tool (the dropping of 1.9.3 support out of the .travis.yml is called out since it has $IMPLICATIONS).