### PR TITLE
Rake options override default options

### DIFF
--- a/lib/foodcritic/rake_task.rb
+++ b/lib/foodcritic/rake_task.rb
@@ -19,7 +19,7 @@ module FoodCritic
         desc 'Lint Chef cookbooks' unless ::Rake.application.last_comment
         task(name) do
           puts "Starting Foodcritic linting..."
-          result = FoodCritic::Linter.new.check(options.merge(default_options))
+          result = FoodCritic::Linter.new.check(default_options.merge(options))
           printer = options[:context] ? ContextOutput.new : SummaryOutput.new
           printer.output(result) if result.warnings.any?
           abort if result.failed?


### PR DESCRIPTION
Fixed the options override logic in rake task.

Could not override default options with previous implementation.