### PR TITLE
Support old-style notifications with ruby 1.9 hash syntax

### DIFF
--- a/lib/foodcritic/notifications.rb
+++ b/lib/foodcritic/notifications.rb
@@ -94,6 +94,9 @@ module FoodCritic
     def old_style_notification(notify)
       resources = resource_hash_references(notify)
       resource_type = resources.xpath("symbol[1]/ident/@value").to_s.to_sym
+      if resource_type.empty?
+        resource_type = resources.xpath("label/@value").to_s.chop.to_sym
+      end
       resource_name = resources.xpath('string_add[1][count(../
         descendant::string_add) = 1]/tstring_content/@value').to_s
       resource_name = resources if resource_name.empty?

--- a/lib/foodcritic/xml.rb
+++ b/lib/foodcritic/xml.rb
@@ -23,7 +23,20 @@ module FoodCritic
       child.each do |c|
         n = xml_create_node(doc, c)
         c.drop(1).each do |a|
-          xml_node.add_child(build_xml(a, doc, n))
+          if a.first == :@label
+            # if the ruby 1.9 hash syntax is used,
+            # the ast like below is generated.
+            # ast:
+            #  [:assoc_new,
+            #   [:@label, "service:", [6, 39]]]
+
+            # create a label node and add it to the accos_new children nodes
+            label_node = xml_create_node(doc, a)
+            n.add_child(build_xml(a, doc, label_node))
+            xml_node.add_child(n)
+          else
+            xml_node.add_child(build_xml(a, doc, n))
+          end
         end
       end
     end

--- a/spec/foodcritic/api_spec.rb
+++ b/spec/foodcritic/api_spec.rb
@@ -853,6 +853,25 @@ describe FoodCritic::Api do
         }]
       )
     end
+    it "understands old-style notifications with ruby 1.9 hash syntax" do
+      api.notifications(parse_ast(%q{
+        template "/etc/nscd.conf" do
+          source "nscd.conf"
+          owner "root"
+          group "root"
+          notifies :restart, resources(service: "nscd")
+        end
+      })).must_equal(
+        [{
+          :type => :notifies,
+          :action => :restart,
+          :resource_type => :service,
+          :resource_name => "nscd",
+          :timing => :delayed,
+          :style => :old,
+        }]
+      )
+    end
     it "understands the old-style subscriptions" do
       api.notifications(parse_ast(%q{
         template "/etc/nscd.conf" do


### PR DESCRIPTION
`foodcritic` raises `ArgumentError` if we run `foodcritic` on recipes that contains old-style notifications with ruby 1.9 Hash syntax.

```ruby:default.rb
service 'ssh' do
  action :nothing
end

file '/var/hoge' do
  action :create
  notifies :restart, resources(service: 'ssh')
end
```

```
> bundle exec foodcritc default.rb
=> foodcritic/chef.rb:69:in `resource_check?': Arguments cannot be nil or empty. (ArgumentError)
```

This commit solves the above issue