### PR TITLE
(On behalf of Lexmark) Fix merging default options

### DIFF
--- a/lib/foodcritic/rake_task.rb
+++ b/lib/foodcritic/rake_task.rb
@@ -19,7 +19,7 @@ module FoodCritic
         desc 'Lint Chef cookbooks' unless ::Rake.application.last_comment
         task(name) do
           puts "Starting Foodcritic linting..."
-          result = FoodCritic::Linter.new.check(options.merge(default_options))
+          result = FoodCritic::Linter.new.check(default_options.merge(options))
           printer = options[:context] ? ContextOutput.new : SummaryOutput.new
           printer.output(result) if result.warnings.any?
           abort if result.failed?


### PR DESCRIPTION
https://github.com/acrmp/foodcritic/commit/1d280d72f7ac37b3b3f8290f06a08a6d86f2d276 inadvertently reversed the order that default options were merged, rendering the user of the Rake task unable to override the defaults.