### PR TITLE
remove duplicate output

### DIFF
--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -79,7 +79,6 @@ module FoodCritic
       files = files_to_process(paths)
 
       if options[:progress]
-        puts "Food Critic"
         puts "Checking #{files.count} files"
       end
 


### PR DESCRIPTION
This line is duplicate output, and has the project name in an incorrect format.

Example output before this change:
```
Starting Foodcritic linting...
Food Critic
Checking 23 files
```