### PR TITLE
add checks for correct use of use_inline_resources

### DIFF
--- a/features/057_check_for_library_provider_without_use_inline_resources.feature
+++ b/features/057_check_for_library_provider_without_use_inline_resources.feature
@@ -1,0 +1,20 @@
+Feature: Check for library providers that do not declare use_inline_resources
+
+  In order to ensure that notifications happen correctly
+  As a cookbook provider author
+  I want to always use_inline_resources
+
+  Scenario: Library provider with use_inline_resources
+    Given a cookbook that contains a library provider with use_inline_resources
+     When I check the cookbook
+     Then the library provider without use_inline_resources warning 057 should not be displayed against the libraries file
+
+  Scenario: Library provider without use_inline_resources
+    Given a cookbook that contains a library provider without use_inline_resources
+     When I check the cookbook
+     Then the library provider without use_inline_resources warning 057 should be displayed against the libraries file on line 11
+
+  Scenario: Library file without use_inline_resources
+    Given a cookbook that contains a library resource
+     When I check the cookbook
+     Then the library provider without use_inline_resources warning 057 should not be displayed against the libraries file

--- a/features/058_check_for_library_provider_bad_action_methods.feature
+++ b/features/058_check_for_library_provider_bad_action_methods.feature
@@ -1,0 +1,25 @@
+Feature: Check for library providers that declare use_inline_resources and declare action_<name> methods
+
+  In order to ensure that notifications happen correctly
+  As a cookbook provider author
+  I want to always use_inline_resources
+
+  Scenario: Library provider with use_inline_resources and bad action_create
+    Given a cookbook that contains a library provider with use_inline_resources and uses def action_create
+     When I check the cookbook
+     Then the library provider without use_inline_resources and bad action_create warning 058 should be displayed against the libraries file on line 11
+
+  Scenario: Library provider without use_inline_resources and (okay) action_create
+    Given a cookbook that contains a library provider without use_inline_resources and uses def action_create
+     When I check the cookbook
+     Then the library provider without use_inline_resources and bad action_create warning 058 should not be displayed against the libraries file
+
+  Scenario: Library provider without use_inline_resources
+    Given a cookbook that contains a library provider without use_inline_resources
+     When I check the cookbook
+     Then the library provider without use_inline_resources and bad action_create warning 058 should not be displayed against the libraries file
+
+  Scenario: Library provider with use_inline_resources
+    Given a cookbook that contains a library provider with use_inline_resources
+     When I check the cookbook
+     Then the library provider without use_inline_resources and bad action_create warning 058 should not be displayed against the libraries file

--- a/features/059_check_for_lwrp_provider_without_use_inline_resources.feature
+++ b/features/059_check_for_lwrp_provider_without_use_inline_resources.feature
@@ -1,0 +1,15 @@
+Feature: Check for LWRP providers that do not declare use_inline_resources
+
+  In order to ensure that notifications happen correctly
+  As a cookbook provider author
+  I want to always use_inline_resources
+
+  Scenario: LWRP provider with use_inline_resources
+    Given a cookbook that contains a LWRP provider with use_inline_resources
+     When I check the cookbook
+     Then the LWRP provider without use_inline_resources warning 059 should not be displayed against the provider file
+
+  Scenario: LWRP provider without use_inline_resources
+    Given a cookbook that contains a LWRP provider without use_inline_resources
+     When I check the cookbook
+     Then the LWRP provider without use_inline_resources warning 059 should be displayed against the provider file

--- a/features/060_check_for_lwrp_provider_bad_action_methods.feature
+++ b/features/060_check_for_lwrp_provider_bad_action_methods.feature
@@ -1,0 +1,25 @@
+Feature: Check for LWRP providers that declare use_inline_resources and declare action_<name> methods
+
+  In order to ensure that notifications happen correctly
+  As a cookbook provider author
+  I want to always use_inline_resources
+
+  Scenario: LWRP provider with use_inline_resources and bad action_create
+    Given a cookbook that contains a LWRP provider with use_inline_resources and uses def action_create
+     When I check the cookbook
+     Then the LWRP provider without use_inline_resources and bad action_create warning 060 should be displayed against the provider file on line 3
+
+  Scenario: LWRP provider without use_inline_resources
+    Given a cookbook that contains a LWRP provider without use_inline_resources
+     When I check the cookbook
+     Then the LWRP provider without use_inline_resources and bad action_create warning 060 should not be displayed against the provider file
+
+  Scenario: LWRP provider without use_inline_resources and (okay) action_create
+    Given a cookbook that contains a LWRP provider without use_inline_resources and uses def action_create
+     When I check the cookbook
+     Then the LWRP provider without use_inline_resources and bad action_create warning 060 should not be displayed against the provider file
+
+  Scenario: LWRP provider with use_inline_resources
+    Given a cookbook that contains a LWRP provider with use_inline_resources
+     When I check the cookbook
+     Then the LWRP provider without use_inline_resources and bad action_create warning 060 should not be displayed against the provider file

--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -67,6 +67,10 @@ module FoodCritic
       # FC054 was yanked and is considered reserved, do not reuse it
       'FC055' => 'Ensure maintainer is set in metadata',
       'FC056' => 'Ensure maintainer_email is set in metadata',
+      'FC057' => 'Library provider does not declare use_inline_resources',
+      'FC058' => 'Library provider declares use_inline_resources and declares #action_<name> methods',
+      'FC059' => 'LWRP provider does not declare use_inline_resources',
+      'FC060' => 'LWRP provider declares use_inline_resources and declares #action_<name> methods',
       'FCTEST001' => 'Test Rule'
     }
 

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -785,3 +785,44 @@ rule 'FC056', 'Ensure maintainer_email is set in metadata' do
     [file_match(filename)] unless field(ast, 'maintainer_email').any?
   end
 end
+
+rule 'FC057', 'Library provider does not declare use_inline_resources' do
+  tags %w(correctness)
+  library do |ast, filename|
+    ast.xpath('//const_path_ref/const[@value="LWRPBase"]/..//const[@value="Provider"]/../../..').select do |x|
+      x.xpath('//*[self::vcall or self::var_ref]/ident[@value="use_inline_resources"]').empty?
+    end
+  end
+end
+
+rule 'FC058', 'Library provider declares use_inline_resources and declares #action_<name> methods' do
+  tags %w(correctness)
+  library do |ast, filename|
+    ast.xpath('//const_path_ref/const[@value="LWRPBase"]/..//const[@value="Provider"]/../../..').select do |x|
+      x.xpath('//*[self::vcall or self::var_ref]/ident[@value="use_inline_resources"]') &&
+        x.xpath(%Q(//def[ident[contains(@value, 'action_')]]))
+    end
+  end
+end
+
+rule 'FC059', 'LWRP provider does not declare use_inline_resources' do
+  tags %w(correctness)
+  provider do |ast, filename|
+    use_inline_resources = !ast.xpath('//*[self::vcall or self::var_ref]/ident
+      [@value="use_inline_resources"]').empty?
+    unless use_inline_resources
+      [file_match(filename)]
+    end
+  end
+end
+
+rule 'FC060', 'LWRP provider declares use_inline_resources and declares #action_<name> methods' do
+  tags %w(correctness)
+  provider do |ast, filename|
+    use_inline_resources = !ast.xpath('//*[self::vcall or self::var_ref]/ident
+      [@value="use_inline_resources"]').empty?
+    if use_inline_resources
+      ast.xpath(%Q(//def[ident[contains(@value, 'action_')]]))
+    end
+  end
+end


### PR DESCRIPTION
- recommend use_inline_resource in all 'LWRPBase' providers
- catch the use of use_inline_resources when users are also declaring
  `def action_whatever` instead of `action :whatever` which defeats
  use_inline_resources