### PR TITLE
fix for edge condition with 061

### DIFF
--- a/features/061_valid_cookbook_version_should_be_defined.feature
+++ b/features/061_valid_cookbook_version_should_be_defined.feature
@@ -39,12 +39,17 @@ Feature: Defined cookbook version should be valid
      When I check the cookbook
      Then the metadata defines valid version warning 061 should be displayed against the metadata file
 
-  Scenario: Metadata version that uses string interpolation' do
+  Scenario: Metadata version that uses string interpolation
     Given a cookbook with a metadata version that uses string interpolation
      When I check the cookbook
      Then the metadata defines valid version warning 061 should not be displayed against the metadata file
 
-  Scenario: Metadata version that is not a string literal' do
+  Scenario: Metadata version that is not a string literal
     Given a cookbook with a metadata version that is not a string literal
+     When I check the cookbook
+     Then the metadata defines valid version warning 061 should not be displayed against the metadata file
+
+  Scenario: Metadata version that is a method call
+    Given a cookbook with a metadata version that is a method call
      When I check the cookbook
      Then the metadata defines valid version warning 061 should not be displayed against the metadata file

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -2455,3 +2455,9 @@ Given 'a cookbook with a metadata version that is not a string literal' do
     version v
   }
 end
+
+Given 'a cookbook with a metadata version that is a method call' do
+  write_metadata %q{
+    version magic_version_generator('and its args')
+  }
+end

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -831,7 +831,7 @@ rule 'FC061', 'Valid cookbook versions are of the form x.y or x.y.z' do
   tags %w{metadata correctness}
   metadata do |ast, filename|
     # matches a version method with a string literal with no interpolation
-    ver = ast.xpath(%Q(//command[ident/@value='version']//string_literal[not(.//string_embexpr)]//tstring_content/@value))
+    ver = ast.xpath('//command[ident/@value="version"]/args_add_block/args_add/string_literal[not(.//string_embexpr)]//tstring_content/@value')
     if !ver.empty? && ver.to_s !~ /\A\d+\.\d+(\.\d+)?\z/
       [file_match(filename)]
     end


### PR DESCRIPTION
differentiates between `version function('arg')` and `version '1.2.3'`
by being strict about the nodes that we traverse.

i'm not sure if there's still a way to attack this via adding siblings,
but its an improvement...