### PR TITLE
Check for URLs that are helpful to the Supermarket

### DIFF
--- a/features/064_check_for_no_issues_url.feature
+++ b/features/064_check_for_no_issues_url.feature
@@ -1,0 +1,25 @@
+Feature: Check for no issues_url
+
+  In order to be able to upload my cookbook
+  As a developer
+  I want to be notified when my cookbook metadata does not specify the issues_url
+
+  Scenario: Metadata without a issues_url
+    Given a cookbook with metadata that does not include a issues_url keyword
+     When I check the cookbook
+     Then the metadata missing issues_url warning 064 should be shown against the metadata file
+
+  Scenario: Metadata with a issues_url
+    Given a cookbook with metadata that includes a issues_url keyword
+     When I check the cookbook
+     Then the metadata missing issues_url warning 064 should be not shown against the metadata file
+
+  Scenario: Metadata with a issues_url that is an expression
+    Given a cookbook with metadata that includes a issues_url expression
+     When I check the cookbook
+     Then the metadata missing issues_url warning 064 should be not shown against the metadata file
+
+  Scenario: Cookbook without metadata file
+    Given a cookbook that does not have defined metadata
+    When I check the cookbook
+    Then the metadata missing issues_url warning 064 should be not shown against the metadata file

--- a/features/064_check_for_no_issues_url.feature
+++ b/features/064_check_for_no_issues_url.feature
@@ -1,6 +1,6 @@
 Feature: Check for no issues_url
 
-  In order to be able to upload my cookbook
+  In order to be able to share my cookbook on the Supermarket
   As a developer
   I want to be notified when my cookbook metadata does not specify the issues_url
 

--- a/features/065_check_for_no_source_url.feature
+++ b/features/065_check_for_no_source_url.feature
@@ -1,0 +1,25 @@
+Feature: Check for no source_url
+
+  In order to be able to share my cookbook on the Supermarket
+  As a developer
+  I want to be notified when my cookbook metadata does not specify the source_url
+
+  Scenario: Metadata without a source_url
+    Given a cookbook with metadata that does not include a source_url keyword
+     When I check the cookbook
+     Then the metadata missing source_url warning 065 should be shown against the metadata file
+
+  Scenario: Metadata with a source_url
+    Given a cookbook with metadata that includes a source_url keyword
+     When I check the cookbook
+     Then the metadata missing source_url warning 065 should be not shown against the metadata file
+
+  Scenario: Metadata with a source_url that is an expression
+    Given a cookbook with metadata that includes a source_url expression
+     When I check the cookbook
+     Then the metadata missing source_url warning 065 should be not shown against the metadata file
+
+  Scenario: Cookbook without metadata file
+    Given a cookbook that does not have defined metadata
+    When I check the cookbook
+    Then the metadata missing source_url warning 065 should be not shown against the metadata file

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -2493,3 +2493,17 @@ Then(/^the metadata with self dependency warning 063 should be (shown|not shown)
     expect_warning('FC063', :file => "metadata.rb", :expect_warning => false)
   end
 end
+
+Given(/^a cookbook with metadata that (includes|does not include) a issues_url keyword$/) do |includes|
+  write_metadata %Q{
+    #{"issues_url 'http://github.com/foo/bar_cookbook/issues'" if includes == 'includes'}
+  }
+end
+
+Given(/^a cookbook with metadata that includes a issues_url expression$/) do
+  write_metadata "issues_url an(expression)"
+end
+
+Then(/^the metadata missing issues_url warning 064 should be (shown|not shown) against the metadata file$/) do |show_warning|
+  expect_warning('FC064', :file => 'metadata.rb', :expect_warning => show_warning == 'shown')
+end

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -2507,3 +2507,17 @@ end
 Then(/^the metadata missing issues_url warning 064 should be (shown|not shown) against the metadata file$/) do |show_warning|
   expect_warning('FC064', :file => 'metadata.rb', :expect_warning => show_warning == 'shown')
 end
+
+Given(/^a cookbook with metadata that (includes|does not include) a source_url keyword$/) do |includes|
+  write_metadata %Q{
+    #{"source_url 'http://github.com/foo/bar_cookbook/'" if includes == 'includes'}
+  }
+end
+
+Then(/^the metadata missing source_url warning (\d+) should be (shown|not shown) against the metadata file$/) do |show_warning|
+  expect_warning('FC065', :file => 'metadata.rb', :expect_warning => show_warning == 'shown')
+end
+
+Given(/^a cookbook with metadata that includes a source_url expression$/) do
+  write_metadata "source_url an(expression)"
+end

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -2514,7 +2514,7 @@ Given(/^a cookbook with metadata that (includes|does not include) a source_url k
   }
 end
 
-Then(/^the metadata missing source_url warning (\d+) should be (shown|not shown) against the metadata file$/) do |show_warning|
+Then(/^the metadata missing source_url warning 065 should be (shown|not shown) against the metadata file$/) do |show_warning|
   expect_warning('FC065', :file => 'metadata.rb', :expect_warning => show_warning == 'shown')
 end
 

--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -75,6 +75,7 @@ module FoodCritic
       'FC062' => 'Cookbook should have version metadata',
       'FC063' => 'Cookbook incorrectly depends on itself',
       'FC064' => 'Ensure issues_url is set in metadata',
+      'FC065' => 'Ensure source_url is set in metadata',
       'FCTEST001' => 'Test Rule'
     }
 

--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -74,6 +74,7 @@ module FoodCritic
       'FC061' => 'Valid cookbook versions are of the form x.y or x.y.z',
       'FC062' => 'Cookbook should have version metadata',
       'FC063' => 'Cookbook incorrectly depends on itself',
+      'FC064' => 'Ensure issues_url is set in metadata',
       'FCTEST001' => 'Test Rule'
     }
 

--- a/features/support/cookbook_helpers.rb
+++ b/features/support/cookbook_helpers.rb
@@ -80,6 +80,7 @@ module FoodCritic
         maintainer_email 'maintainer@example.com'
         version '0.0.1'
         issues_url 'http://github.com/foo/bar_cookbook/issues'
+        source_url 'http://github.com/foo/bar_cookbook'
       ).strip)
     end
 

--- a/features/support/cookbook_helpers.rb
+++ b/features/support/cookbook_helpers.rb
@@ -79,6 +79,7 @@ module FoodCritic
         maintainer 'A Maintainer'
         maintainer_email 'maintainer@example.com'
         version '0.0.1'
+        issues_url 'http://github.com/foo/bar_cookbook/issues'
       ).strip)
     end
 

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -861,3 +861,10 @@ rule 'FC063', 'Cookbook incorrectly depends on itself' do
               descendant::tstring_content[@value='#{name}']))
   end
 end
+
+rule 'FC064', 'Ensure issues_url is set in metadata' do
+  tags %w(metadata supermarket)
+  metadata do |ast, filename|
+    [file_match(filename)] unless field(ast, 'issues_url').any?
+  end
+end

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -868,3 +868,10 @@ rule 'FC064', 'Ensure issues_url is set in metadata' do
     [file_match(filename)] unless field(ast, 'issues_url').any?
   end
 end
+
+rule 'FC065', 'Ensure source_url is set in metadata' do
+  tags %w(metadata supermarket)
+  metadata do |ast, filename|
+    [file_match(filename)] unless field(ast, 'source_url').any?
+  end
+end

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -864,6 +864,9 @@ end
 
 rule 'FC064', 'Ensure issues_url is set in metadata' do
   tags %w(metadata supermarket)
+  applies_to do |version|
+    version >= gem_version('12.0.0')
+  end
   metadata do |ast, filename|
     [file_match(filename)] unless field(ast, 'issues_url').any?
   end
@@ -871,6 +874,9 @@ end
 
 rule 'FC065', 'Ensure source_url is set in metadata' do
   tags %w(metadata supermarket)
+  applies_to do |version|
+    version >= gem_version('12.0.0')
+  end
   metadata do |ast, filename|
     [file_match(filename)] unless field(ast, 'source_url').any?
   end


### PR DESCRIPTION
This PR introduces two new rules:

* FC064 - Ensure issues_url is set in metadata
* FC065 - Ensure source_url is set in metadata

In order to be able to share my cookbook on the Supermarket
As a developer
I want to be notified when my cookbook metadata does not specify the source_url or issues_url

I realize that not everyone who uses Foodcritic does so with the expectation that their cookbook will be shared on the Supermarket.  As such, I'm proposing a new tag `supermarket` be added.  Currently, I've tagged these two rules with both `metadata` and  `supermarket`.

Implementing these two rules in Foodcritic will make the implementation of https://github.com/chef-cookbooks/cookbook-quality-metrics/ easier.