### PR TITLE
Fix FC058 false positives

### DIFF
--- a/features/058_check_for_library_provider_bad_action_methods.feature
+++ b/features/058_check_for_library_provider_bad_action_methods.feature
@@ -12,14 +12,14 @@ Feature: Check for library providers that declare use_inline_resources and decla
   Scenario: Library provider without use_inline_resources and (okay) action_create
     Given a cookbook that contains a library provider without use_inline_resources and uses def action_create
      When I check the cookbook
-     Then the library provider without use_inline_resources and bad action_create warning 058 should not be displayed against the libraries file
+     Then the library provider without use_inline_resources and bad action_create warning 058 should not be displayed against the libraries file on any line
 
   Scenario: Library provider without use_inline_resources
     Given a cookbook that contains a library provider without use_inline_resources
      When I check the cookbook
-     Then the library provider without use_inline_resources and bad action_create warning 058 should not be displayed against the libraries file
+     Then the library provider without use_inline_resources and bad action_create warning 058 should not be displayed against the libraries file on any line
 
   Scenario: Library provider with use_inline_resources
     Given a cookbook that contains a library provider with use_inline_resources
      When I check the cookbook
-     Then the library provider without use_inline_resources and bad action_create warning 058 should not be displayed against the libraries file
+     Then the library provider without use_inline_resources and bad action_create warning 058 should not be displayed against the libraries file on any line

--- a/features/step_definitions/cookbook_steps.rb
+++ b/features/step_definitions/cookbook_steps.rb
@@ -2099,7 +2099,7 @@ Then /^the warning ([0-9]+ )?should (not )?be (?:displayed|shown)$/ do |warning,
   expect_warning code, {:expect_warning => should_not.nil?}
 end
 
-Then /^the (?:[a-zA-Z \-_]+) warning ([0-9]+) should (not )?be displayed(?: against the (attributes|libraries|definition|metadata|provider|resource|README.md|README.rdoc) file)?( below)?(?: on line ([0-9]+))?$/ do |code, no_display, file, warning_only, line|
+Then /^the (?:[a-zA-Z \-_]+) warning ([0-9]+) should (not )?be displayed(?: against the (attributes|libraries|definition|metadata|provider|resource|README.md|README.rdoc) file)?( below)?(?: on (?:(any line)|(?:line ([0-9]+))))?$/ do |code, no_display, file, warning_only, any_line, line|
   options = {}
   options[:expect_warning] = no_display != 'not '
   unless file.nil?
@@ -2111,7 +2111,13 @@ Then /^the (?:[a-zA-Z \-_]+) warning ([0-9]+) should (not )?be displayed(?: agai
   end
   options[:line] = 3 if code == '018' and options[:expect_warning]
   options[:line] = 2 if ['021', '022'].include?(code)
-  options[:line] = line unless line.nil?
+
+  if any_line
+    options[:line] = nil
+  else
+    options[:line] = line unless line.nil?
+  end
+
   options[:warning_only] = ! warning_only.nil?
   expect_warning("FC#{code}", options)
 end

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -801,8 +801,8 @@ rule 'FC058', 'Library provider declares use_inline_resources and declares #acti
   end
   library do |ast, filename|
     ast.xpath('//const_path_ref/const[@value="LWRPBase"]/..//const[@value="Provider"]/../../..').select do |x|
-      x.xpath('//*[self::vcall or self::var_ref]/ident[@value="use_inline_resources"]') &&
-        x.xpath(%Q(//def[ident[contains(@value, 'action_')]]))
+      x.xpath('//*[self::vcall or self::var_ref]/ident[@value="use_inline_resources"]').length > 0 &&
+        x.xpath(%Q(//def[ident[contains(@value, 'action_')]])).length > 0
     end
   end
 end


### PR DESCRIPTION
There were multiple issues here. First, the test did not
correctly catch this because the wrong match specification
was being created due to line number not being specified.
Instead of defaulting to nil, it defaulted to 1, making
2 incorrect things look correct together.

Second, FC058 needed to check the length of the array
was greater than so, as `[]` defaults to truthy.

cc @lamont-granquist @tas50 @sersut

Should fix https://github.com/acrmp/foodcritic/issues/419