### PR TITLE
Rake.last_comment was depreciated in Rake11.

### DIFF
--- a/lib/foodcritic/rake_task.rb
+++ b/lib/foodcritic/rake_task.rb
@@ -16,7 +16,7 @@ module FoodCritic
 
 
       def define
-        desc 'Lint Chef cookbooks' unless ::Rake.application.last_comment
+        desc 'Lint Chef cookbooks' unless ::Rake.application.last_description
         task(name) do
           puts "Starting Foodcritic linting..."
           result = FoodCritic::Linter.new.check(default_options.merge(options))


### PR DESCRIPTION
See https://github.com/ruby/rake/commit/e76242ce7ef94568399a50b69bda4b723dab7c75