### PR TITLE
FC032 allow the new :before timing on resource notifications in Chef >= 12.6.0

### DIFF
--- a/features/032_check_for_invalid_notification_timing.feature
+++ b/features/032_check_for_invalid_notification_timing.feature
@@ -6,17 +6,21 @@ Feature: Check for invalid notification timings
 
   Scenario Outline: Notification timings
     Given a cookbook recipe with a resource that <type> <notification_timing>
-    When I check the cookbook
+    When I check the cookbook specifying <version> as the Chef version
     Then the invalid notification timing warning 032 <display> be displayed
   Examples:
-    | type       | notification_timing | display     |
-    | notifies   |                     | should not  |
-    | notifies   | immediately         | should not  |
-    | notifies   | immediate           | should not  |
-    | notifies   | delayed             | should not  |
-    | notifies   | imediately          | should      |
-    | subscribes |                     | should not  |
-    | subscribes | immediately         | should not  |
-    | subscribes | immediate           | should not  |
-    | subscribes | delayed             | should not  |
-    | subscribes | imediately          | should      |
+    | type       | notification_timing | version | display     |
+    | notifies   |                     | 12.6.0  | should not  |
+    | notifies   | before              | 12.4.0  | should      |
+    | notifies   | before              | 12.6.0  | should not  |
+    | notifies   | immediately         | 12.6.0  | should not  |
+    | notifies   | immediate           | 12.6.0  | should not  |
+    | notifies   | delayed             | 12.6.0  | should not  |
+    | notifies   | imediately          | 12.6.0  | should      |
+    | subscribes |                     | 12.6.0  | should not  |
+    | subscribes | before              | 12.4.0  | should      |
+    | subscribes | before              | 12.6.0  | should not  |
+    | subscribes | immediately         | 12.6.0  | should not  |
+    | subscribes | immediate           | 12.6.0  | should not  |
+    | subscribes | delayed             | 12.6.0  | should not  |
+    | subscribes | imediately          | 12.6.0  | should      |

--- a/lib/foodcritic/notifications.rb
+++ b/lib/foodcritic/notifications.rb
@@ -50,7 +50,7 @@ module FoodCritic
             # The target resource action.
             action: notification_action(notify),
 
-            # The notification timing. Either `:immediate` or `:delayed`.
+            # The notification timing: `:before`, `:immediate` or `:delayed`.
             timing: notification_timing(notify)
           }
         )

--- a/lib/foodcritic/rules.rb
+++ b/lib/foodcritic/rules.rb
@@ -482,9 +482,14 @@ end
 rule 'FC032', 'Invalid notification timing' do
   tags %w(correctness notifications)
   recipe do |ast|
+    valid_timings = if resource_attribute?('file', 'notifies_before') then
+      [:delayed, :immediate, :before]
+    else
+      [:delayed, :immediate]
+    end
     find_resources(ast).select do |resource|
       notifications(resource).any? do |notification|
-        ! [:delayed, :immediate].include? notification[:timing]
+        ! valid_timings.include? notification[:timing]
       end
     end
   end


### PR DESCRIPTION
Since Chef 12.6.0 resource notifications now support a :before timing (in addition to :immediately and :delayed)
```
package "foo" do
  action :upgrade
  notifies :stop, "service[blah]", :before
end
```
When using :before, foodcritic rule `FC032: Invalid notification timing` will fail.

https://github.com/chef/chef-rfc/blob/master/rfc058-before.md
https://github.com/chef/chef/pull/4062
https://tickets.opscode.com/browse/CHEF-2421