### PR TITLE
Include gemspec and Gemfiles in distributed gem for ease of working with / running tests

### DIFF
--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.files = Dir['chef_dsl_metadata/*.json'] +
     Dir['lib/**/*.rb'] +
     Dir['misc/**/*']
+  s.files += Dir['Rakefile'] + Dir['Gemfile'] + Dir["*.gemspec"]
   s.files += Dir['spec/**/*'] + Dir['features/**/*']
   s.files += Dir['*.md'] + Dir['LICENSE'] + Dir['man/*']
   s.required_ruby_version = '>= 2.0.0'


### PR DESCRIPTION
This helps with some improvements we're making with our build system to pull more things from rubygems releases.