### PR TITLE
Use latest gherkin (faster install)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Gemfile.lock
 .rvmrc
 /.bundle/
 /tags
+binstubs/

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'foodcritic', :path => '.'
 
 group :test do
   gem 'aruba', '~> 0.5'
-  gem 'cucumber', '~> 1.3'
+  gem 'cucumber', '>= 2'
   gem 'minitest', '~> 5.3'
   gem 'simplecov', '~> 0.8'
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,7 +10,6 @@ end
 require 'aruba/cucumber'
 require 'foodcritic'
 
-require 'minitest/autorun'
 require 'minitest/spec'
 
 MiniTest::Spec.new(nil)

--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.executables << 'foodcritic'
   s.required_ruby_version = ">= 2.0.0"
-  s.add_dependency('gherkin', '~> 2.11')
+  s.add_dependency('cucumber-core', '>= 1.3')
   s.add_dependency('nokogiri', '>= 1.5', '< 2.0')
   s.add_dependency('rake')
   s.add_dependency('treetop', '~> 1.4')

--- a/lib/foodcritic.rb
+++ b/lib/foodcritic.rb
@@ -1,5 +1,5 @@
 require 'pathname'
-require 'gherkin'
+require 'cucumber/core'
 require 'treetop'
 require 'ripper'
 require 'yajl'

--- a/lib/foodcritic/domain.rb
+++ b/lib/foodcritic/domain.rb
@@ -1,4 +1,4 @@
-require 'gherkin/tag_expression'
+require 'cucumber/core/gherkin/tag_expression'
 
 module FoodCritic
   # A warning of a possible issue
@@ -95,9 +95,9 @@ module FoodCritic
 
     # Checks the rule tags to see if they match a Gherkin (Cucumber) expression
     def matches_tags?(tag_expr)
-      Gherkin::TagExpression.new(tag_expr).evaluate(tags.map do |t|
-        Gherkin::Formatter::Model::Tag.new(t, 1)
-      end)
+      Cucumber::Core::Gherkin::TagExpression.new(tag_expr).evaluate(
+        tags.map { |tag| Cucumber::Core::Ast::Tag.new(nil, tag) }
+      )
     end
 
     # Returns a string representation of this rule.

--- a/spec/foodcritic/api_spec.rb
+++ b/spec/foodcritic/api_spec.rb
@@ -138,7 +138,7 @@ describe FoodCritic::Api do
   end
 
   describe "#checks_for_chef_solo?" do
-    let(:ast) { ast = MiniTest::Mock.new }
+    let(:ast) { MiniTest::Mock.new }
     it "raises if the provided ast does not support XPath" do
       lambda{api.checks_for_chef_solo?(nil)}.must_raise(ArgumentError)
     end
@@ -459,7 +459,7 @@ describe FoodCritic::Api do
   end
 
   describe "#literal_searches" do
-    let(:ast) { ast = MiniTest::Mock.new }
+    let(:ast) { MiniTest::Mock.new }
     it "returns empty if the AST does not support XPath expressions" do
       api.literal_searches(nil).must_be_empty
     end
@@ -1642,7 +1642,7 @@ describe FoodCritic::Api do
   end
 
   describe "#searches" do
-    let(:ast) { ast = MiniTest::Mock.new }
+    let(:ast) { MiniTest::Mock.new }
     it "returns empty if the AST does not support XPath expressions" do
       api.searches('not-an-ast').must_be_empty
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ rescue LoadError
   warn 'warning: simplecov gem not found; skipping coverage'
 end
 
-require 'minitest/autorun'
 require 'minitest/pride'
 require 'minitest/spec'
 


### PR DESCRIPTION
gherkin 2 is incredibly slow to install on Windows, with a ton of .so's building. This patch gets us working against gherkin 3 (the classes in question have moved to cucumber-core, as you can see).

closes #372 