### PR TITLE
More sane default CLI values

### DIFF
--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -8,13 +8,14 @@ module FoodCritic
       @args = args
       @original_args = args.dup
       @options = {
-        fail_tags: [],
+        fail_tags: ['any'],
         tags: [],
         include_rules: [],
         cookbook_paths: [],
         role_paths: [],
         environment_paths: [],
-        exclude_paths: [],
+        exclude_paths: ['test/**/*', 'spec/**/*', 'features/**/*'],
+        progress: true
       }
       @parser = OptionParser.new do |opts|
         opts.banner = "foodcritic [cookbook_paths]"
@@ -27,9 +28,9 @@ module FoodCritic
                 "List all enabled rules and their descriptions.") do |t|
           @options[:list] = t
         end
-        opts.on("-f", "--epic-fail TAGS",
-                "Fail the build based on tags. Use 'any' to fail "\
-                "on all warnings.") do |t|
+        opts.on('-f', '--epic-fail TAGS',
+                "Fail the build based on tags. Default of 'any' to fail "\
+                'on all warnings.') do |t|
           @options[:fail_tags] << t
         end
         opts.on("-c", "--chef-version VERSION",
@@ -59,9 +60,9 @@ module FoodCritic
                 "foodcritic/rules/**/*.rb") do |g|
           @options[:search_gems] = true
         end
-        opts.on("-P", "--progress",
-                "Show progress of files being checked") do
-          @options[:progress] = true
+        opts.on('-P', '--[no-]progress',
+                'Show progress of files being checked. default:  true') do |q|
+          @options[:progress] = q
         end
         opts.on("-R", "--role-path PATH",
                 "Role path(s) to check.") do |r|
@@ -76,7 +77,7 @@ module FoodCritic
           @options[:version] = true
         end
         opts.on("-X", "--exclude PATH",
-                "Exclude path(s) from being linted. PATH is relative to the cookbook, not an absolute PATH") do |e|
+                "Exclude path(s) from being linted. PATH is relative to the cookbook, not an absolute PATH. Default test/**/*,spec/**/*,features/**/*") do |e|
           options[:exclude_paths] << e
         end
       end


### PR DESCRIPTION
1) Turn the progress on by default.  Foodcritic doing nothing by default is just plain odd. If someone wants silent output they should specify so
2) Skip files in test, spec, and features by default.  We're skipping these in the Rake task currently and test cookbooks almost always cause false alarms in FC. This will speed up the runs and improve user workflow.
3) Fail on any tag by default. It's odd that out of the box we show failures, but don't throw proper exit codes for them. This probably leads to a lot of incorrectly configured test jobs. I know I've done it wrong in the past (a few times). If someone wants to limit what they fail on they should specify it since that's flow is out of the norm.
