### PR TITLE
Remove support for Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 # Foodcritic
-[![Build Status](https://travis-ci.org/acrmp/foodcritic.svg?branch=master)](https://travis-ci.org/acrmp/foodcritic)
-[![Gem Version](https://badge.fury.io/rb/foodcritic.svg)](http://badge.fury.io/rb/foodcritic)
 
-Foodcritic is a lint tool for Chef cookbooks. It requires Ruby 2.0.0+.
+[![Build Status](https://travis-ci.org/acrmp/foodcritic.svg?branch=master)](https://travis-ci.org/acrmp/foodcritic) [![Gem Version](https://badge.fury.io/rb/foodcritic.svg)](http://badge.fury.io/rb/foodcritic)
+
+Foodcritic is a lint tool for Chef cookbooks. It requires Ruby 2.1.0+.
 
 # Homepage
-[http://foodcritic.io/](http://foodcritic.io/)
+
+<http://foodcritic.io/>
 
 # Building
 
-    $ bundle install
-    $ bundle exec rake
+```
+$ bundle install
+$ bundle exec rake
+```
 
 # Continuous Integration
+
 [Foodcritic on Travis CI](http://travis-ci.org/acrmp/foodcritic)
 
 # License
+
 MIT - see the accompanying [LICENSE](https://github.com/acrmp/foodcritic/blob/master/LICENSE) file for details.
 
 # Changelog

--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://foodcritic.io'
   s.license = 'MIT'
   s.executables << 'foodcritic'
-  s.required_ruby_version = ">= 2.0.0"
+  s.required_ruby_version = '>= 2.1.0'
   s.add_dependency('cucumber-core', '>= 1.3')
   s.add_dependency('nokogiri', '>= 1.5', '< 2.0')
   s.add_dependency('rake')


### PR DESCRIPTION
Ruby 2.0 is EOL. We should only support currently Ruby releases. I'd remove support for 2.1 as well, but that's what ChefDK ships with so we can't.