### PR TITLE
Add missing assigment attributes

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -536,9 +536,12 @@ module FoodCritic
             default!
             default_unless
             force_default
+            force_default!
             force_override
+            force_override!
             node
             normal
+            normal!
             normal_unless
             override
             override!


### PR DESCRIPTION
Add a few missing attributes to fix rule FC047 false positives.

Related issue
https://github.com/acrmp/foodcritic/issues/477