### PR TITLE
Require Ruby 2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Foodcritic site at <http://foodcritic.io/> contains documentation for each o
 
 ## Requirements
 
-- Ruby 2.1+
+- Ruby 2.2.2+
 
 ## Building Foodcritic
 

--- a/foodcritic.gemspec
+++ b/foodcritic.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://foodcritic.io"
   s.license = "MIT"
   s.executables << "foodcritic"
-  s.required_ruby_version = ">= 2.1.0"
+  s.required_ruby_version = ">= 2.2.2"
   s.add_dependency("cucumber-core", ">= 1.3")
   s.add_dependency("nokogiri", ">= 1.5", "< 2.0")
   s.add_dependency("rake")


### PR DESCRIPTION
Due to rack deps we need to drop 2.1

Signed-off-by: Tim Smith <tsmith@chef.io>