### PR TITLE
Clarify exclude path instructions

### DIFF
--- a/lib/foodcritic/command_line.rb
+++ b/lib/foodcritic/command_line.rb
@@ -76,7 +76,7 @@ module FoodCritic
           @options[:version] = true
         end
         opts.on("-X", "--exclude PATH",
-                "Exclude path(s) from being linted.") do |e|
+                "Exclude path(s) from being linted. PATH is relative to the cookbook, not an absolute PATH") do |e|
           options[:exclude_paths] << e
         end
       end


### PR DESCRIPTION
When I was beginning to use foodcritic, it was detecting the test subdirectory of some of our cookbooks as another cookbook and throwing false FC011, FC031 and FC045 errors.

When I was trying to exclude the test directory tree, I read the instructions as needing to specify an absolute path, not one relative to the cookbook directory.

This PR spells that out in the `--help` output.

Closes #488 