### PR TITLE
Add a more robust base path helper to the API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :test do
   gem "aruba", "~> 0.5"
   gem "cucumber", ">= 2"
   gem "minitest", "~> 5.3"
+  gem "minitest-reporters"
   gem "simplecov", "~> 0.8"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,10 @@ group :test do
   gem "minitest", "~> 5.3"
   gem "minitest-reporters"
   gem "simplecov", "~> 0.8"
+  gem "chefstyle", "~> 0.5"
 end
 
 group :development do
-  gem "chef", "~> 12.1"
-  gem "chefstyle", "~> 0.4"
   gem "ronn", "~> 0.7"
 end
 

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -89,7 +89,7 @@ module FoodCritic
 
       # get list of items in the dir and intersect with metadata array.
       # until we get an interfact (we have a metadata) walk up the dir structure
-      until (Dir.entries(file) & %w(metadata.rb metadata.json)).any?
+      until (Dir.entries(file) & %w{metadata.rb metadata.json}).any?
         file = File.absolute_path(File.dirname(file.to_s))
       end
 

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -95,7 +95,7 @@ module FoodCritic
       # get list of items in the dir and intersect with metadata array.
       # until we get an interfact (we have a metadata) walk up the dir structure
       until (Dir.entries(file) & %w{metadata.rb metadata.json}).any?
-        file = File.absolute_path(File.dirname(file.to_s))
+        file = File.dirname(file)
       end
 
       file

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -77,6 +77,20 @@ module FoodCritic
       end
     end
 
+    # The absolute path of a cookbook from the specified file.
+    def cookbook_base_path(file)
+      file = File.expand_path(file) # make sure we get an absolute path
+      file = File.dirname(file) unless File.directory?(file) # get the dir only
+
+      # get list of items in the dir and intersect with metadata array.
+      # until we get an interfact (we have a metadata) walk up the dir structure
+      until (Dir.entries(file) & %w(metadata.rb metadata.json)).any?
+        file = File.absolute_path(File.dirname(file.to_s))
+      end
+
+      file
+    end
+
     # Support function to retrieve a metadata field
     def metadata_field(file, field)
       until (file.split(File::SEPARATOR) & standard_cookbook_subdirs).empty?

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -33,6 +33,9 @@ module FoodCritic
     end
 
     # Does the specified recipe check for Chef Solo?
+    #
+    # @deprecated chef-solo functionality in Chef has been replaced with local-mode
+    #  so this helper is no longer necessary and will be removed in Foodcritic 11.0
     def checks_for_chef_solo?(ast)
       puts "the checks_for_chef_solo? helper is deprecated and will be removed from the next release of Foodcritic"
       raise_unless_xpath!(ast)
@@ -52,9 +55,11 @@ module FoodCritic
         end == %w{Chef Config}
     end
 
-    # Is the
-    # [chef-solo-search library](https://github.com/edelight/chef-solo-search)
-    # available?
+    # Is the chef-solo-search library available?
+    #
+    # @see https://github.com/edelight/chef-solo-search
+    # @deprecated chef-solo functionality in Chef has been replaced with local-mode
+    #  so this helper is no longer necessary and will be removed in Foodcritic 11.0
     def chef_solo_search_supported?(recipe_path)
       puts "the chef_solo_search_supported? helper is deprecated and will be removed from the next release of Foodcritic"
       return false if recipe_path.nil? || !File.exist?(recipe_path)

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -78,6 +78,11 @@ module FoodCritic
     end
 
     # The absolute path of a cookbook from the specified file.
+    #
+    # @author Tim Smith - tsmith@chef.io
+    # @since 11.0
+    # @param file [String, Pathname] relative or absolute path to a file in the cookbook
+    # @return [String] the absolute path to the base of the cookbook
     def cookbook_base_path(file)
       file = File.expand_path(file) # make sure we get an absolute path
       file = File.dirname(file) unless File.directory?(file) # get the dir only

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -34,6 +34,7 @@ module FoodCritic
 
     # Does the specified recipe check for Chef Solo?
     def checks_for_chef_solo?(ast)
+      puts "the checks_for_chef_solo? helper is deprecated and will be removed from the next release of Foodcritic"
       raise_unless_xpath!(ast)
       # TODO: This expression is too loose, but also will fail to match other
       # types of conditionals.
@@ -55,6 +56,7 @@ module FoodCritic
     # [chef-solo-search library](https://github.com/edelight/chef-solo-search)
     # available?
     def chef_solo_search_supported?(recipe_path)
+      puts "the chef_solo_search_supported? helper is deprecated and will be removed from the next release of Foodcritic"
       return false if recipe_path.nil? || !File.exist?(recipe_path)
 
       # Look for the chef-solo-search library.

--- a/spec/foodcritic/api_spec.rb
+++ b/spec/foodcritic/api_spec.rb
@@ -19,6 +19,7 @@ describe FoodCritic::Api do
         :chef_dsl_methods,
         :chef_node_methods,
         :chef_solo_search_supported?,
+        :cookbook_base_path,
         :cookbook_maintainer,
         :cookbook_maintainer_email,
         :cookbook_name,

--- a/spec/foodcritic/api_spec.rb
+++ b/spec/foodcritic/api_spec.rb
@@ -170,6 +170,40 @@ describe FoodCritic::Api do
     end
   end
 
+  describe "#cookbook_base_path" do
+    # TODO we should do this with a double instead
+    # but this is the accepted pattern so far so...
+    def mock_cookbook(metadata_path)
+      dir = File.dirname(metadata_path)
+      unless File.directory?(dir)
+        FileUtils.mkdir_p(dir)
+      end
+      File.open(metadata_path, "w") { |file| file.write('name "YOUR_COOKBOOK_NAME"') }
+      FileUtils.mkdir_p(File.join(dir, "templates/defaults"))
+      File.open(File.join(dir, "templates", "defaults", "test.erb"), "w") { |file| file.write("Some erb") }
+    end
+
+    it "returns the cookbook dir when passed the path itself" do
+      mock_cookbook("/tmp/fc/mock/cb/metadata.rb")
+      api.cookbook_base_path("/tmp/fc/mock/cb/").must_equal "/tmp/fc/mock/cb"
+    end
+
+    it "returns the cookbook dir when passed a nested directory" do
+      mock_cookbook("/tmp/fc/mock/cb/metadata.rb")
+      api.cookbook_base_path("/tmp/fc/mock/cb/templates/defaults/test.erb").must_equal "/tmp/fc/mock/cb"
+    end
+
+    it "returns the cookbook dir when path contains cookbook like names" do
+      mock_cookbook("/tmp/fc/mock/resources/cb/metadata.rb")
+      api.cookbook_base_path("/tmp/fc/mock/resources/cb/templates/defaults/test.erb").must_equal "/tmp/fc/mock/resources/cb"
+    end
+
+    it "returns the cookbook dir when path has a metadata.json not metadata.rb" do
+      mock_cookbook("/tmp/fc/mock/cb/metadata.json")
+      api.cookbook_base_path("/tmp/fc/mock/cb/templates/defaults/test.erb").must_equal "/tmp/fc/mock/cb"
+    end
+  end
+
   describe "#cookbook_name" do
     def mock_cookbook_metadata(f)
       dir = File.dirname(f)

--- a/spec/foodcritic/linter_spec.rb
+++ b/spec/foodcritic/linter_spec.rb
@@ -11,7 +11,7 @@ describe FoodCritic::Linter do
 
   describe "chef version" do
     it "should be the latest stable version of Chef" do
-      FoodCritic::Linter::DEFAULT_CHEF_VERSION.must_equal "12.4.1"
+      FoodCritic::Linter::DEFAULT_CHEF_VERSION.must_equal "12.19.36"
     end
   end
 
@@ -54,20 +54,21 @@ describe FoodCritic::Linter do
   end
 
   describe "#load_files!" do
-    let(:default_rules_file) do
-      File.expand_path(File.join(File.dirname(__FILE__), "../../lib/foodcritic/rules.rb"))
+    let(:default_rule_files) do
+      # an array of each of the absolute paths to the default rules
+      Dir.glob(File.expand_path(File.join(File.dirname(__FILE__), "../../lib/foodcritic/rules/*")))
     end
 
     let(:rule_dsl_load_mock) { MiniTest::Mock.new }
 
     it "should add the default rule file" do
-      rule_dsl_load_mock.expect(:call, nil, [[default_rules_file], nil])
+      rule_dsl_load_mock.expect(:call, nil, [default_rule_files, nil])
       verify_loaded
     end
 
     it "should include rules found in gems if the :search_gems option is true" do
       gem_rules = ["/path/to/rules1.rb", "/path/to/rules2.rb"]
-      expected_rules = [default_rules_file, gem_rules].flatten
+      expected_rules = [*default_rule_files, *gem_rules]
       rule_dsl_load_mock.expect(:call, nil, [expected_rules, nil])
 
       metaclass = class << linter; self; end
@@ -80,7 +81,7 @@ describe FoodCritic::Linter do
 
     it "should include files found in :include_rules option" do
       include_rules = ["/path/to/rules1.rb", "/path/to/rules2.rb"]
-      expected_rules = [default_rules_file, include_rules].flatten
+      expected_rules = [*default_rule_files, *include_rules]
       rule_dsl_load_mock.expect(:call, nil, [expected_rules, nil])
 
       verify_loaded :include_rules => include_rules

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,9 @@ rescue LoadError
   warn "warning: simplecov gem not found; skipping coverage"
 end
 
-require "minitest/pride"
 require "minitest/spec"
+require "minitest/autorun"
+require "minitest/reporters"
+MiniTest::Reporters.use!
 
 require_relative "../lib/foodcritic"


### PR DESCRIPTION
The current methods of discovering the base path are flawed as they fail if the cookbook is within a directory named the same as a cookbook directory (templates, recipes, files, etc). This gives us an actual helper for finding the base path of a cookbook. We can migrate existing api calls and rules over to this in the future.

Signed-off-by: Tim Smith <tsmith@chef.io>