### PR TITLE
Make the violate_rule matcher a tad more magical

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,17 +10,26 @@ end
 module FunctionalHelpers
   extend RSpec::Matchers::DSL
 
-  matcher :violate_rule do |rule_id|
+  matcher :violate_rule do |_rule_id=nil|
     match do |cmd|
       if location
-        cmd.stdout =~ /^#{rule_id}:.*: \.\/#{location}/
+        cmd.stdout =~ /^#{expected}:.*: \.\/#{location}/
       else
-        cmd.stdout =~ /^#{rule_id}:/
+        cmd.stdout =~ /^#{expected}:/
       end
     end
     chain :in, :location
     failure_message do |cmd|
-      "expected a violation of rule #{rule_id}#{location && " in #{location}"}, output was:\n#{cmd.stdout}"
+      "expected a violation of rule #{expected}#{location && " in #{location}"}, output was:\n#{cmd.stdout}"
+    end
+    failure_message_when_negated do |cmd|
+      "expected no violation of rule #{expected}#{location && " in #{location}"}, output was:\n#{cmd.stdout}"
+    end
+    # Override the default behavior from RSpec for the expected value, use
+    # define_method insetad of def so we can see the _rule_id variable in closure.
+    define_method(:expected) do
+      # Fill in the top-level example group description as the rule ID if not specified.
+      _rule_id || method_missing(:class).parent_groups.last.description
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ end
 module FunctionalHelpers
   extend RSpec::Matchers::DSL
 
-  matcher :violate_rule do |_rule_id=nil|
+  matcher :violate_rule do |rule_id = nil|
     match do |cmd|
       if location
         cmd.stdout =~ /^#{expected}:.*: \.\/#{location}/
@@ -29,7 +29,7 @@ module FunctionalHelpers
     # define_method insetad of def so we can see the _rule_id variable in closure.
     define_method(:expected) do
       # Fill in the top-level example group description as the rule ID if not specified.
-      _rule_id || method_missing(:class).parent_groups.last.description
+      rule_id || method_missing(:class).parent_groups.last.description
     end
   end
 


### PR DESCRIPTION
This allows using `violate_rule` with no parameter in a test, it will use the description label of the top-level example group. Mostly avoids re-typing the rule ID in every functional test. Also add a nice description for negated matches.

@tas50 does this seem like excessive magic for the benefit?