### PR TITLE
Root alias stuffs

### DIFF
--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -257,7 +257,7 @@ module FoodCritic
 
           if File.directory?(dir)
             glob = if path_type == :cookbook
-                     "{metadata.rb,{attributes,definitions,libraries,"\
+                     "{metadata.rb,attributes.rb,recipe.rb,{attributes,definitions,libraries,"\
                      "providers,recipes,resources}/*.rb,templates/*/*.erb}"
                    else
                      "*.rb"

--- a/lib/foodcritic/rules/fc073.rb
+++ b/lib/foodcritic/rules/fc073.rb
@@ -2,7 +2,7 @@ rule "FC073", "Root alias file shadowing non-alias file" do
   tags %w{correctness}
   cookbook do |path|
     {
-      "attributes.rb" => "default/attributes.rb",
+      "attributes.rb" => "attributes/default.rb",
       "recipe.rb" => "recipes/default.rb",
     }.map do |alias_path, folder_path|
       full_alias_path = File.join(path, alias_path)

--- a/lib/foodcritic/rules/fc073.rb
+++ b/lib/foodcritic/rules/fc073.rb
@@ -1,0 +1,17 @@
+rule "FC073", "Root alias file shadowing non-alias file" do
+  tags %w{correctness}
+  cookbook do |path|
+    {
+      "attributes.rb" => "default/attributes.rb",
+      "recipe.rb" => "recipes/default.rb",
+    }.map do |alias_path, folder_path|
+      full_alias_path = File.join(path, alias_path)
+      full_folder_path = File.join(path, folder_path)
+      if File.exist?(full_alias_path) && File.exist?(full_folder_path)
+        file_match(full_folder_path)
+      else
+        nil
+      end
+    end.compact
+  end
+end

--- a/lib/foodcritic/rules/fc073.rb
+++ b/lib/foodcritic/rules/fc073.rb
@@ -1,5 +1,5 @@
 rule "FC073", "Root alias file shadowing non-alias file" do
-  tags %w{correctness}
+  tags %w{correctness chef13}
   cookbook do |path|
     {
       "attributes.rb" => "attributes/default.rb",

--- a/spec/functional/fc073_spec.rb
+++ b/spec/functional/fc073_spec.rb
@@ -3,6 +3,54 @@ require "spec_helper"
 describe "FC073" do
   context "with an empty cookbook" do
     metadata_file
-    fit { is_expected.to_not violate_rule }
+    it { is_expected.to_not violate_rule("FC073") }
+  end
+
+  context "with only attributes/default.rb" do
+    metadata_file
+    attributes_file
+    it { is_expected.to_not violate_rule("FC073") }
+  end
+
+  context "with only attributes.rb" do
+    metadata_file
+    file "attributes.rb"
+    it { is_expected.to_not violate_rule("FC073") }
+  end
+
+  context "with both attributes.rb and attributes/default.rb" do
+    metadata_file
+    file "attributes.rb"
+    attributes_file
+    it { is_expected.to violate_rule("FC073").in("attributes/default.rb") }
+  end
+
+  context "with only recipes/default.rb" do
+    metadata_file
+    recipe_file
+    it { is_expected.to_not violate_rule("FC073") }
+  end
+
+  context "with only recipe.rb" do
+    metadata_file
+    file "recipe.rb"
+    it { is_expected.to_not violate_rule("FC073") }
+  end
+
+  context "with both recipe.rb and recipes/default.rb" do
+    metadata_file
+    file "recipe.rb"
+    recipe_file
+    it { is_expected.to violate_rule("FC073").in("recipes/default.rb") }
+  end
+
+  context "with all four" do
+    metadata_file
+    file "attributes.rb"
+    file "recipe.rb"
+    attributes_file
+    recipe_file
+    it { is_expected.to violate_rule("FC073").in("attributes/default.rb") }
+    it { is_expected.to violate_rule("FC073").in("recipes/default.rb") }
   end
 end

--- a/spec/functional/fc073_spec.rb
+++ b/spec/functional/fc073_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+
+describe "FC073" do
+  context "with an empty cookbook" do
+    metadata_file
+    fit { is_expected.to_not violate_rule }
+  end
+end

--- a/spec/functional/root_aliases_spec.rb
+++ b/spec/functional/root_aliases_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+fdescribe "root aliases" do
+  context "with a recipe root alias" do
+    file "recipe.rb", "log node[:foo]\n"
+    it { is_expected.to violate_rule("FC001") }
+  end
+
+  context "with an attributes root alias" do
+    file "attributes.rb", "default[:foo] = 1\n"
+    it { is_expected.to violate_rule("FC001") }
+  end
+end

--- a/spec/functional/root_aliases_spec.rb
+++ b/spec/functional/root_aliases_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-fdescribe "root aliases" do
+describe "root aliases" do
   context "with a recipe root alias" do
     file "recipe.rb", "log node[:foo]\n"
     it { is_expected.to violate_rule("FC001") }


### PR DESCRIPTION
Includes a fix (with test) for scanning root alias files and a new rule to detect the case of alias collision.