### PR TITLE
Fix FC024 to not consider amazon equivalent to RHEL platforms

### DIFF
--- a/features/024_check_for_missing_platforms.feature
+++ b/features/024_check_for_missing_platforms.feature
@@ -14,9 +14,8 @@ Feature: Check for missing platforms
       | type      | supports                    | flavours                                              | warning             |
       | case      |                             | chalk,cheese                                          | should not be shown |
       | case      |                             | debian,ubuntu                                         | should not be shown |
-      | case      |                             | amazon,centos,redhat,scientific,oracle                | should not be shown |
-      | case      |                             | centos,redhat,amazon,scientific,oracle                | should not be shown |
-      | case      |                             | centos,debian,fedora,redhat,amazon,scientific,oracle  | should not be shown |
+      | case      |                             | centos,redhat,scientific,oracle                       | should not be shown |
+      | case      |                             | centos,debian,fedora,redhat,scientific,oracle         | should not be shown |
       | case      |                             | redhat                                                | should not be shown |
       | case      |                             | centos,redhat                                         | should be shown     |
       | case      | centos,redhat               | centos,redhat                                         | should not be shown |
@@ -25,7 +24,7 @@ Feature: Check for missing platforms
       | case      | centos,debian,scientific    | centos,scientific                                     | should not be shown |
       | case      | centos,redhat,scientific    | redhat,scientific                                     | should be shown     |
       | case      | debian,redhat,centos,fedora | redhat,centos,fedora                                  | should not be shown |
-      | platform? |                             | centos,redhat,amazon,scientific,oracle                | should not be shown |
+      | platform? |                             | centos,redhat,scientific,oracle                       | should not be shown |
       | platform? |                             | redhat                                                | should not be shown |
       | platform? |                             | redhat,scientific                                     | should be shown     |
       | platform? | redhat,scientific           | redhat,scientific                                     | should not be shown |

--- a/lib/foodcritic/rules/fc024.rb
+++ b/lib/foodcritic/rules/fc024.rb
@@ -1,6 +1,6 @@
 rule "FC024", "Consider adding platform equivalents" do
   tags %w{portability}
-  RHEL = %w{amazon centos redhat scientific oracle}
+  RHEL = %w{centos redhat scientific oracle}
   recipe do |ast, filename|
     next if Pathname.new(filename).basename.to_s == "metadata.rb"
     metadata_path = Pathname.new(

--- a/spec/regression/expected/mysql.txt
+++ b/spec/regression/expected/mysql.txt
@@ -3,8 +3,6 @@ FC002: Avoid string interpolation where not required: ./attributes/server.rb:206
 FC002: Avoid string interpolation where not required: ./attributes/server.rb:207
 FC002: Avoid string interpolation where not required: ./attributes/server.rb:208
 FC007: Ensure recipe dependencies are reflected in cookbook metadata: ./recipes/client.rb:42
-FC024: Consider adding platform equivalents: ./recipes/server.rb:130
-FC024: Consider adding platform equivalents: ./recipes/server.rb:132
 FC052: Metadata uses the unimplemented "suggests" keyword: ./metadata.rb:19
 FC052: Metadata uses the unimplemented "suggests" keyword: ./metadata.rb:20
 FC064: Ensure issues_url is set in metadata: ./metadata.rb:1


### PR DESCRIPTION
Amazon is its own platform family now

Signed-off-by: Tim Smith <tsmith@chef.io>