### PR TITLE
Add FC074 to detect non-dsl default action setup

### DIFF
--- a/lib/foodcritic/rules/fc074.rb
+++ b/lib/foodcritic/rules/fc074.rb
@@ -1,0 +1,10 @@
+rule "FC074", "LWRP should use DSL to define resource's default action" do
+  tags %w{correctness lwrp}
+  resource do |ast, filename|
+    # See if we're in a custom resource not an LWRP. Only LWRPs need the default_action
+    if ["//def/bodystmt/descendant::assign/
+      var_field/ivar/@value='@action'"].any? { |expr| ast.xpath(expr) }
+      [file_match(filename)]
+    end
+  end
+end

--- a/spec/functional/fc074_spec.rb
+++ b/spec/functional/fc074_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe "FC074" do
+
+  context "with a cookbook with a LWRP that includes a default_action" do
+    resource_file <<-EOH
+      actions :create, :remove
+      default_action :create
+
+      attribute :name, String, name_attribute: true
+    EOH
+    it { is_expected.to_not violate_rule("FC074") }
+  end
+
+  context "with a cookbook with a LWRP that includes a non-DSL default_action" do
+    resource_file <<-EOH
+      actions :create, :remove,
+
+      def initialize(*args)
+        super
+        @action = :create
+      end
+
+      attribute :name, String, name_attribute: true
+    EOH
+    it { is_expected.to violate_rule("FC074") }
+  end
+
+  context "with a custom resource" do
+    resource_file <<-EOH
+      property :name, String, name_property: true
+
+      action :create do
+        cookbook_file "/etc/something"
+      end
+    EOH
+    it { is_expected.to_not violate_rule("FC074") }
+  end
+end

--- a/spec/regression/expected/apt.txt
+++ b/spec/regression/expected/apt.txt
@@ -8,3 +8,5 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/preference.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/repository.rb:1

--- a/spec/regression/expected/aws.txt
+++ b/spec/regression/expected/aws.txt
@@ -7,3 +7,7 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC067: Ensure at least one platform supported in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/ebs_volume.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/elastic_ip.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/elastic_lb.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/resource_tag.rb:1

--- a/spec/regression/expected/chef_handler.txt
+++ b/spec/regression/expected/chef_handler.txt
@@ -4,3 +4,4 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC067: Ensure at least one platform supported in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/default.rb:1

--- a/spec/regression/expected/cron.txt
+++ b/spec/regression/expected/cron.txt
@@ -4,3 +4,4 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/d.rb:1

--- a/spec/regression/expected/dmg.txt
+++ b/spec/regression/expected/dmg.txt
@@ -9,3 +9,4 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/package.rb:1

--- a/spec/regression/expected/firewall.txt
+++ b/spec/regression/expected/firewall.txt
@@ -8,3 +8,5 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC067: Ensure at least one platform supported in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/default.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/rule.rb:1

--- a/spec/regression/expected/gunicorn.txt
+++ b/spec/regression/expected/gunicorn.txt
@@ -5,3 +5,5 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC067: Ensure at least one platform supported in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/config.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/install.rb:1

--- a/spec/regression/expected/homebrew.txt
+++ b/spec/regression/expected/homebrew.txt
@@ -5,3 +5,4 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/tap.rb:1

--- a/spec/regression/expected/iis.txt
+++ b/spec/regression/expected/iis.txt
@@ -24,3 +24,7 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/app.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/config.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/pool.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/site.rb:1

--- a/spec/regression/expected/lvm.txt
+++ b/spec/regression/expected/lvm.txt
@@ -7,3 +7,6 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/logical_volume.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/physical_volume.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/volume_group.rb:1

--- a/spec/regression/expected/maven.txt
+++ b/spec/regression/expected/maven.txt
@@ -6,3 +6,4 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/default.rb:1

--- a/spec/regression/expected/powershell.txt
+++ b/spec/regression/expected/powershell.txt
@@ -5,3 +5,4 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/default.rb:1

--- a/spec/regression/expected/sudo.txt
+++ b/spec/regression/expected/sudo.txt
@@ -5,3 +5,4 @@ FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC072: Metadata should not contain "attribute" keyword: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/default.rb:1

--- a/spec/regression/expected/users.txt
+++ b/spec/regression/expected/users.txt
@@ -4,3 +4,4 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/manage.rb:1

--- a/spec/regression/expected/webpi.txt
+++ b/spec/regression/expected/webpi.txt
@@ -4,3 +4,4 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/product.rb:1

--- a/spec/regression/expected/windows.txt
+++ b/spec/regression/expected/windows.txt
@@ -45,3 +45,13 @@ FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/auto_run.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/batch.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/feature.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/package.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/path.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/reboot.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/registry.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/shortcut.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/task.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/zipfile.rb:1

--- a/spec/regression/expected/yum.txt
+++ b/spec/regression/expected/yum.txt
@@ -13,3 +13,5 @@ FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
 FC069: Ensure standardized license defined in metadata: ./metadata.rb:1
 FC070: Ensure supports metadata defines valid platforms: ./metadata.rb:1
 FC072: Metadata should not contain "attribute" keyword: ./metadata.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/key.rb:1
+FC074: LWRP should use DSL to define resource's default action: ./resources/repository.rb:1


### PR DESCRIPTION
I see these all over the place and I don't think most people understand why they're even including it. We should make sure people are aware that these are no longer necessary / desired.

Signed-off-by: Tim Smith <tsmith@chef.io>