### PR TITLE
Add FC075 to detect node.save

### DIFF
--- a/lib/foodcritic/rules/fc075.rb
+++ b/lib/foodcritic/rules/fc075.rb
@@ -1,0 +1,9 @@
+rule "FC075", "Cookbook uses node.save to save data to the chef-server mid-run" do
+  tags %w{correctness}
+  def node_saves(ast)
+    ast.xpath('//call[(vcall|var_ref)/ident/@value="node"]
+    [ident/@value="save"]')
+  end
+  recipe { |ast| node_saves(ast) }
+  library { |ast| node_saves(ast) }
+end

--- a/lib/foodcritic/rules/fc075.rb
+++ b/lib/foodcritic/rules/fc075.rb
@@ -1,4 +1,4 @@
-rule "FC075", "Cookbook uses node.save to save data to the chef-server mid-run" do
+rule "FC075", "Cookbook uses node.save to save partial node data to the chef-server mid-run" do
   tags %w{correctness}
   def node_saves(ast)
     ast.xpath('//call[(vcall|var_ref)/ident/@value="node"]

--- a/spec/functional/fc075_spec.rb
+++ b/spec/functional/fc075_spec.rb
@@ -12,8 +12,13 @@ describe "FC075" do
     it { is_expected.not_to violate_rule("FC075") }
   end
 
+  context "with a cookbook with recipe that includes node['save']" do
+    recipe_file("node['save']")
+    it { is_expected.not_to violate_rule("FC075") }
+  end
+
   context "with a cookbook with a library that uses node.save" do
-    libary_file <<-EOH
+    library_file <<-EOH
       module CookbookHelper
         def some_method
           node.save

--- a/spec/functional/fc075_spec.rb
+++ b/spec/functional/fc075_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe "FC075" do
+
+  context "with a cookbook with recipe that uses node.save" do
+    recipe_file "node.save"
+    it { is_expected.to violate_rule("FC075") }
+  end
+
+  context "with a cookbook with recipe that doesn't use node.save" do
+    recipe_file
+    it { is_expected.not_to violate_rule("FC075") }
+  end
+
+  context "with a cookbook with a library that uses node.save" do
+    libary_file <<-EOH
+      module CookbookHelper
+        def some_method
+          node.save
+        end
+      end
+    EOH
+    it { is_expected.to violate_rule("FC075") }
+  end
+
+  context "with a cookbook with a custom resource that uses node.save" do
+    resource_file <<-EOH
+      property :name, String, name_property: true
+
+      action :create do
+        node.save
+      end
+    EOH
+    it { is_expected.to violate_rule("FC075") }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,8 +68,8 @@ module FunctionalHelpers
       file("resources/my_resource.rb", *args, &block)
     end
 
-    def libary_file(*args, &block)
-      file("resources/helper.rb", *args, &block)
+    def library_file(*args, &block)
+      file("library/helper.rb", *args, &block)
     end
 
     def recipe_file(*args, &block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,7 +69,7 @@ module FunctionalHelpers
     end
 
     def library_file(*args, &block)
-      file("library/helper.rb", *args, &block)
+      file("libraries/helper.rb", *args, &block)
     end
 
     def recipe_file(*args, &block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,10 @@ module FunctionalHelpers
       file("resources/my_resource.rb", *args, &block)
     end
 
+    def libary_file(*args, &block)
+      file("resources/helper.rb", *args, &block)
+    end
+
     def recipe_file(*args, &block)
       file("recipes/default.rb", *args, &block)
     end


### PR DESCRIPTION
node.save is something you should only do if you REALLY know what you’re doing and are entirely sure actually you want a node.save to occur. Most people don’t need it and we really don’t want community cookbooks randomly saving the node (some do)

Signed-off-by: Tim Smith <tsmith@chef.io>