### PR TITLE
Simplify FC045 by using the field helper

### DIFF
--- a/lib/foodcritic/rules/fc045.rb
+++ b/lib/foodcritic/rules/fc045.rb
@@ -1,13 +1,6 @@
 rule "FC045", "Metadata does not contain cookbook name" do
   tags %w{correctness metadata chef12}
   metadata do |ast, filename|
-    unless ast.xpath('descendant::stmts_add/command/ident/@value="name"')
-      [file_match(filename)]
-    end
-  end
-  cookbook do |filename|
-    if !File.exist?(File.join(filename, "metadata.rb"))
-      [file_match(File.join(filename, "metadata.rb"))]
-    end
+    [file_match(filename)] unless field(ast, "name").any?
   end
 end

--- a/spec/functional/fc045_spec.rb
+++ b/spec/functional/fc045_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "FC045" do
   context "with a cookbook with a metadata file that includes the name keyword" do
     metadata_file "name 'food'"
-    it { is_expected.to_not violate_rule("45") }
+    it { is_expected.to_not violate_rule("FC045") }
   end
 
   context "with a cookbook with a metadata file that doesn't include the name keyword" do
@@ -13,6 +13,6 @@ describe "FC045" do
 
   context "with a cookbook without a metadata file" do
     recipe_file
-    it { is_expected.to violate_rule("FC045") }
+    it { is_expected.to_not violate_rule("FC045") }
   end
 end

--- a/spec/regression/expected/rsync.txt
+++ b/spec/regression/expected/rsync.txt
@@ -2,7 +2,6 @@ FC011: Missing README in markdown format: examples/README.md:1
 FC017: LWRP does not notify when updated: ./providers/serve.rb:65
 FC017: LWRP does not notify when updated: ./providers/serve.rb:69
 FC031: Cookbook without metadata.rb file: examples/metadata.rb:1
-FC045: Metadata does not contain cookbook name: examples/metadata.rb:1
 FC059: LWRP provider does not declare use_inline_resources: ./providers/serve.rb:1
 FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1


### PR DESCRIPTION
Also don’t fail if there isn’t metadata. We have a check for that already and there’s work in progress to fallback to metadata.json for metadata parsing.

Signed-off-by: Tim Smith <tsmith@chef.io>