### PR TITLE
Fix a regression when running Foodcritic as a Rake task

### DIFF
--- a/lib/foodcritic/rake_task.rb
+++ b/lib/foodcritic/rake_task.rb
@@ -19,7 +19,11 @@ module FoodCritic
         task(name) do
           puts "Starting Foodcritic linting..."
           result = FoodCritic::Linter.new.check(default_options.merge(options))
-          printer = options[:context] ? ContextOutput.new : SummaryOutput.new
+          printer = if options[:context]
+                      ContextOutput.new($stdout)
+                    else
+                      SummaryOutput.new($stdout)
+                    end
           printer.output(result) if result.warnings.any?
           abort if result.failed?
           puts "Completed!"


### PR DESCRIPTION
The Output classes' initializers now [require](https://github.com/acrmp/foodcritic/commit/3c057cb857939b6761effb386fe0b30e9270add2)
an output stream argument.

Signed-off-by: Jonathan Hartman <j@p4nt5.com>