### PR TITLE
Remove Chef Solo APIs and add one for parsing JSON

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -1,5 +1,6 @@
 require "nokogiri"
 require "rufus-lru"
+require "json"
 
 module FoodCritic
   # Helper methods that form part of the Rules DSL.
@@ -414,7 +415,7 @@ module FoodCritic
       file = File.read(filename)
       begin
         JSON.parse(file)
-      rescue JSON::ParserError
+      rescue RuntimeError
         raise "File #{filename} does not appear to contain valid JSON"
       end
     end

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -451,6 +451,23 @@ module FoodCritic
         File.basename(path) == ".DS_Store" || File.extname(path) == ".swp"
       end
     end
+    
+    # Give a filename path it returns the hash of the JSON contents
+    #
+    # @author Tim Smith - tsmith@chef.io
+    # @since 11.0
+    # @param filename [String] path to a file in JSON format
+    # @return [Hash] hash of JSON content
+    def json_file_to_hash(filename)
+      raise "File #{filename} not found" unless File.exist?(filename)
+
+      file = File.read(filename)
+      begin
+        JSON.parse(file)
+      rescue JSON::ParserError
+        raise "File #{filename} does not appear to contain valid JSON"
+      end
+    end
 
     private
 

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -113,7 +113,11 @@ module FoodCritic
       file
     end
 
-    # Support function to retrieve a metadata field
+    # Retrieves a value of a metadata field.
+    #
+    # @author Miguel Fonseca
+    # @since 7.0.0
+    # @return [String] the value of the metadata field
     def metadata_field(file, field)
       until (file.split(File::SEPARATOR) & standard_cookbook_subdirs).empty?
         file = File.absolute_path(File.dirname(file.to_s))
@@ -133,6 +137,9 @@ module FoodCritic
     end
 
     # The name of the cookbook containing the specified file.
+    #
+    # @param file [String] file within a cookbook
+    # @return [String] name of the cookbook
     def cookbook_name(file)
       raise ArgumentError, "File cannot be nil or empty" if file.to_s.empty?
 
@@ -149,14 +156,20 @@ module FoodCritic
       end
     end
 
-    # The maintainer of the cookbook containing the specified file.
+    # Return metadata maintainer property given any file in the cookbook
+    #
+    # @param file [String] file within a cookbook
+    # @return [String] the maintainer of the cookbook
     def cookbook_maintainer(file)
       raise ArgumentError, "File cannot be nil or empty" if file.to_s.empty?
 
       metadata_field(file, "maintainer")
     end
 
-    # The maintainer email of the cookbook containing the specified file.
+    # Return metadata maintainer_email property given any file in the cookbook
+    #
+    # @param file [String] file within a cookbook
+    # @return [String] email of the maintainer of the cookbook
     def cookbook_maintainer_email(file)
       raise ArgumentError, "File cannot be nil or empty" if file.to_s.empty?
 
@@ -376,6 +389,9 @@ module FoodCritic
     end
 
     # The list of standard cookbook sub-directories.
+    #
+    # @since 1.0.0
+    # @return [array] array of all default sub-directories in a cookbook
     def standard_cookbook_subdirs
       %w{attributes definitions files libraries providers recipes resources
          templates}

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -1895,4 +1895,22 @@ describe FoodCritic::Api do
     end
   end
 
+  describe "#json_file_to_hash" do
+
+    it "raises if the filename is not provided" do
+      expect { api.json_file_to_hash }.to raise_error ArgumentError
+    end
+
+    it "raises if the filename is not found" do
+      expect(::File).to receive(:exist?).with("/some/path/with/a/file").and_return(false)
+      expect { api.json_file_to_hash("/some/path/with/a/file") }.to raise_error
+    end
+
+    it "raises if the json is not valid" do
+      expect(::File).to receive(:exist?).with("/some/path/with/a/file").and_return(true)
+      allow(File).to receive(:read).with("/some/path/with/a/file").and_return("I am bogus data")
+      expect { api.json_file_to_hash("/some/path/with/a/file") }.to raise_error JSON::ParserError
+    end
+  end
+
 end

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -15,10 +15,8 @@ describe FoodCritic::Api do
     it "exposes the expected api to rule authors" do
       expect(api.public_methods.sort - ignorable_methods).to eq [
         :attribute_access,
-        :checks_for_chef_solo?,
         :chef_dsl_methods,
         :chef_node_methods,
-        :chef_solo_search_supported?,
         :cookbook_base_path,
         :cookbook_maintainer,
         :cookbook_maintainer_email,
@@ -31,6 +29,7 @@ describe FoodCritic::Api do
         :find_resources,
         :gem_version,
         :included_recipes,
+        :json_file_to_hash,
         :literal_searches,
         :match,
         :metadata_field,
@@ -135,50 +134,6 @@ describe FoodCritic::Api do
         })
         expect(api.attribute_access(ast, :ignore => %w{foo bar})).to be_empty
       end
-    end
-  end
-
-  describe "#checks_for_chef_solo?" do
-    let(:ast) { double() }
-    around do |ex|
-      begin
-        $stderr = StringIO.new
-        ex.run
-      ensure
-        $stderr = STDERR
-      end
-    end
-    it "raises if the provided ast does not support XPath" do
-      expect { api.checks_for_chef_solo?(nil) }.to raise_error ArgumentError
-    end
-    it "returns false if there is no reference to chef solo" do
-      expect(ast).to receive(:xpath).with(kind_of(String)).and_return([]).twice
-      expect(api.checks_for_chef_solo?(ast)).to be_falsey
-    end
-    it "returns true if there is one reference to chef solo" do
-      expect(ast).to receive(:xpath).with(kind_of(String)).and_return(["aref"])
-      expect(api.checks_for_chef_solo?(ast)).to be_truthy
-    end
-    it "returns true if there are multiple references to chef solo" do
-      expect(ast).to receive(:xpath).with(kind_of(String)).and_return(%w{aref aref})
-      expect(api.checks_for_chef_solo?(ast)).to be_truthy
-    end
-  end
-
-  describe "#chef_solo_search_supported?" do
-    around do |ex|
-      begin
-        $stderr = StringIO.new
-        ex.run
-      ensure
-        $stderr = STDERR
-      end
-    end
-    it "returns false if the recipe path is nil" do
-      expect(api.chef_solo_search_supported?(nil)).to be_falsey
-    end
-    it "returns false if the recipe path does not exist" do
-      expect(api.chef_solo_search_supported?("/tmp/non-existent-path")).to be_falsey
     end
   end
 


### PR DESCRIPTION
Remove the previously deprecated Chef Solo APIs, minor updates to docs, and add a new API for parsing JSON to a hash. This was previously part of my larger PR to fix FC045, which I'm breaking up.