### PR TITLE
“All Rights Reserved” cookbooks shouldn’t fail the license file check

### DIFF
--- a/lib/foodcritic/rules/fc071.rb
+++ b/lib/foodcritic/rules/fc071.rb
@@ -1,6 +1,8 @@
 rule "FC071", "Missing LICENSE file" do
   tags %w{style license}
   cookbook do |path|
-    ensure_file_exists(path, "LICENSE")
+    unless (::File.exist?('metadata.rb') && field_value(read_ast('metadata.rb'), "license") == 'All Rights Reserved')
+      ensure_file_exists(path, "LICENSE")
+    end
   end
 end

--- a/lib/foodcritic/rules/fc071.rb
+++ b/lib/foodcritic/rules/fc071.rb
@@ -1,7 +1,7 @@
 rule "FC071", "Missing LICENSE file" do
   tags %w{style license}
   cookbook do |path|
-    unless (::File.exist?('metadata.rb') && field_value(read_ast('metadata.rb'), "license") == 'All Rights Reserved')
+    unless ::File.exist?("metadata.rb") && field_value(read_ast("metadata.rb"), "license") == "All Rights Reserved"
       ensure_file_exists(path, "LICENSE")
     end
   end

--- a/spec/functional/fc071_spec.rb
+++ b/spec/functional/fc071_spec.rb
@@ -11,4 +11,9 @@ describe "FC071" do
     metadata_file "name 'mycookbook'"
     it { is_expected.to violate_rule("FC071") }
   end
+
+  context "with a cookbook without a LICENSE file but with license of 'All Rights Reserved'" do
+    metadata_file "license 'All Rights Reserved'"
+    it { is_expected.not_to violate_rule("FC071") }
+  end
 end


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>