### PR TITLE
Update the metadata rules to use "deprecated" vs "unimplemented"

### DIFF
--- a/features/support/command_helpers.rb
+++ b/features/support/command_helpers.rb
@@ -62,8 +62,8 @@ module FoodCritic
       "FC049" => "Role name does not match containing file name",
       "FC050" => "Name includes invalid characters",
       "FC051" => "Template partials loop indefinitely",
-      "FC052" => 'Metadata uses the unimplemented "suggests" keyword',
-      "FC053" => 'Metadata uses the unimplemented "recommends" keyword',
+      "FC052" => 'Metadata uses the deprecated "suggests" keyword',
+      "FC053" => 'Metadata uses the deprecated "recommends" keyword',
       # FC054 was yanked and is considered reserved, do not reuse it
       "FC055" => "Ensure maintainer is set in metadata",
       "FC056" => "Ensure maintainer_email is set in metadata",

--- a/lib/foodcritic/rules/fc052.rb
+++ b/lib/foodcritic/rules/fc052.rb
@@ -1,4 +1,4 @@
-rule "FC052", 'Metadata uses the unimplemented "suggests" keyword' do
+rule "FC052", 'Metadata uses the deprecated "suggests" keyword' do
   tags %w{style metadata deprecated}
   metadata do |ast, filename|
     ast.xpath(%q{//command[ident/@value='suggests']})

--- a/lib/foodcritic/rules/fc053.rb
+++ b/lib/foodcritic/rules/fc053.rb
@@ -1,4 +1,4 @@
-rule "FC053", 'Metadata uses the unimplemented "recommends" keyword' do
+rule "FC053", 'Metadata uses the deprecated "recommends" keyword' do
   tags %w{style metadata deprecated}
   metadata do |ast, filename|
     ast.xpath(%q{//command[ident/@value='recommends']})

--- a/lib/foodcritic/rules/fc076.rb
+++ b/lib/foodcritic/rules/fc076.rb
@@ -1,4 +1,4 @@
-rule "FC076", 'Metadata uses the unimplemented "conflicts" keyword' do
+rule "FC076", 'Metadata uses the deprecated "conflicts" keyword' do
   tags %w{metadata deprecated chef13}
   metadata do |ast, filename|
     [file_match(filename)] if field(ast, "conflicts").any?

--- a/lib/foodcritic/rules/fc077.rb
+++ b/lib/foodcritic/rules/fc077.rb
@@ -1,4 +1,4 @@
-rule "FC077", 'Metadata uses the unimplemented "replaces" keyword' do
+rule "FC077", 'Metadata uses the deprecated "replaces" keyword' do
   tags %w{metadata deprecated chef13}
   metadata do |ast, filename|
     [file_match(filename)] if field(ast, "replaces").any?

--- a/spec/regression/expected/boost.txt
+++ b/spec/regression/expected/boost.txt
@@ -1,5 +1,5 @@
 FC007: Ensure recipe dependencies are reflected in cookbook metadata: ./recipes/source.rb:1
-FC053: Metadata uses the unimplemented "recommends" keyword: ./metadata.rb:12
+FC053: Metadata uses the deprecated "recommends" keyword: ./metadata.rb:12
 FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1

--- a/spec/regression/expected/build-essential.txt
+++ b/spec/regression/expected/build-essential.txt
@@ -1,5 +1,5 @@
 FC007: Ensure recipe dependencies are reflected in cookbook metadata: ./recipes/default.rb:65
-FC052: Metadata uses the unimplemented "suggests" keyword: ./metadata.rb:14
+FC052: Metadata uses the deprecated "suggests" keyword: ./metadata.rb:14
 FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1

--- a/spec/regression/expected/mysql.txt
+++ b/spec/regression/expected/mysql.txt
@@ -3,8 +3,8 @@ FC002: Avoid string interpolation where not required: ./attributes/server.rb:206
 FC002: Avoid string interpolation where not required: ./attributes/server.rb:207
 FC002: Avoid string interpolation where not required: ./attributes/server.rb:208
 FC007: Ensure recipe dependencies are reflected in cookbook metadata: ./recipes/client.rb:42
-FC052: Metadata uses the unimplemented "suggests" keyword: ./metadata.rb:19
-FC052: Metadata uses the unimplemented "suggests" keyword: ./metadata.rb:20
+FC052: Metadata uses the deprecated "suggests" keyword: ./metadata.rb:19
+FC052: Metadata uses the deprecated "suggests" keyword: ./metadata.rb:20
 FC064: Ensure issues_url is set in metadata: ./metadata.rb:1
 FC065: Ensure source_url is set in metadata: ./metadata.rb:1
 FC066: Ensure chef_version is set in metadata: ./metadata.rb:1


### PR DESCRIPTION
Unimplemented doesn't convey the reason you should remove these from
your code. If you're on 11, 12, or 13 you want these gone

Signed-off-by: Tim Smith <tsmith@chef.io>