### PR TITLE
Ignore case when checking for "All Rights Reserved" in FC071

### DIFF
--- a/lib/foodcritic/rules/fc071.rb
+++ b/lib/foodcritic/rules/fc071.rb
@@ -1,7 +1,7 @@
 rule "FC071", "Missing LICENSE file" do
   tags %w{style license}
   cookbook do |path|
-    unless ::File.exist?("metadata.rb") && field_value(read_ast("metadata.rb"), "license") == "All Rights Reserved"
+    unless ::File.exist?("metadata.rb") && field_value(read_ast("metadata.rb"), "license").casecmp("All Rights Reserved") == 0
       ensure_file_exists(path, "LICENSE")
     end
   end


### PR DESCRIPTION
We should not care about the case of the proprietary license, due to there not being a SPDX standard.