### PR TITLE
Use the given cookbook path in FC071

### DIFF
--- a/lib/foodcritic/rules/fc071.rb
+++ b/lib/foodcritic/rules/fc071.rb
@@ -1,7 +1,7 @@
 rule "FC071", "Missing LICENSE file" do
   tags %w{style license}
   cookbook do |path|
-    unless ::File.exist?("metadata.rb") && field_value(read_ast("metadata.rb"), "license") == "All Rights Reserved"
+    unless ::File.exist?(File.join(path, "metadata.rb")) && field_value(read_ast(File.join(path, "metadata.rb")), "license") == "All Rights Reserved"
       ensure_file_exists(path, "LICENSE")
     end
   end

--- a/spec/functional/fc071_spec.rb
+++ b/spec/functional/fc071_spec.rb
@@ -16,4 +16,16 @@ describe "FC071" do
     metadata_file "license 'All Rights Reserved'"
     it { is_expected.not_to violate_rule("FC071") }
   end
+
+  context "with a cookbook without a LICENSE file, using a sub folder" do
+    subject { foodcritic_command("--no-progress", "mycookbook/") }
+    file "mycookbook/metadata.rb"
+    it { is_expected.to violate_rule("FC071") }
+  end
+
+  context "with a cookbook without a LICENSE file but with license of 'All Rights Reserved', using a sub folder" do
+    subject { foodcritic_command("--no-progress", "mycookbook/") }
+    file "mycookbook/metadata.rb", "license 'All Rights Reserved'"
+    it { is_expected.not_to violate_rule("FC071") }
+  end
 end


### PR DESCRIPTION
This fix the rule FC071 when used with a cookbook path:

    foodcritic -t FC071 my-cookbook

The file `metadata.rb` doesn't exist in the current folder but it does
in `my-cookbook`.