### PR TITLE
Remove Github Changelog Generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,3 @@ group :development do
   gem "ronn", "~> 0.7"
   gem "pry"
 end
-
-group :changelog do
-  # This fork has many fixes we want to use. Once this gets merged upstream we can use the gem again
-  gem "github_changelog_generator", git: "https://github.com/tduffield/github-changelog-generator", branch: "adjust-tag-section-mapping"
-end

--- a/Rakefile
+++ b/Rakefile
@@ -34,22 +34,6 @@ RuboCop::RakeTask.new do |task|
   task.options << "--display-cop-names"
 end
 
-begin
-  require "github_changelog_generator/task"
-  require_relative "../lib/foodcritic/version"
-
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.header = "# Foodcritic Changelog:"
-    config.future_release = FoodCritic::VERSION
-    config.add_issues_wo_labels = false
-    config.enhancement_labels = "enhancement,Enhancement,Enhancements,New Feature,Feature".split(",")
-    config.bug_labels = "bug,Bug,Improvement,Upstream Bug".split(",")
-    config.exclude_labels = "duplicate,question,invalid,wontfix,no_changelog,Exclude From Changelog,Question,Discussion,Tech Cleanup".split(",")
-  end
-rescue LoadError
-  puts "github_changelog_generator is not available. gem install github_changelog_generator to generate changelogs"
-end
-
 desc "Build the manpage"
 task(:man) do
   sh "ronn -w --roff man/*.ronn"


### PR DESCRIPTION
A good changelog communicates what changed, why it was changes, and what the impact is. An autogenerated changelog communicates none of that and frankly github changelog generator has been nothing but trouble everywhere we’ve added it in Chef. It’s much easier to just write a changelog by hand where you convey the changes to the users and explain why it matters to them.

Signed-off-by: Tim Smith <tsmith@chef.io>