### PR TITLE
Strip leading whitespace on platforms to fix FC070

### DIFF
--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -393,7 +393,7 @@ module FoodCritic
       platforms.map do |platform|
         versions = platform.xpath('ancestor::args_add[position() > 1]/
 	  string_literal/descendant::tstring_content/@value').map { |v| v.to_s }
-        { platform: platform["value"], versions: versions }
+        { platform: platform["value"].lstrip, versions: versions }
       end.sort { |a, b| a[:platform] <=> b[:platform] }
     end
 

--- a/spec/functional/fc070_spec.rb
+++ b/spec/functional/fc070_spec.rb
@@ -35,4 +35,22 @@ describe "FC070" do
     metadata_file "supports 'ubuntu >= 16.04'"
     it { is_expected.to violate_rule("FC070") }
   end
+
+  context "with a cookbook with a metadata file specifying a valid supports platforms from an array" do
+    metadata_file <<-'EOH'
+    %w(
+      amazon
+      centos
+      debian
+      fedora
+      redhat
+      scientific
+      oracle
+      ubuntu
+    ).each do |os|
+      supports os
+    end
+    EOH
+    it { is_expected.to_not violate_rule("FC070") }
+  end
 end


### PR DESCRIPTION
This fails due to the way the AST is parsed, but is totally valid Ruby. Our helper for determining the supported platforms in the metadata needed to strip leading whitespace.

    %w(
      amazon
      centos
      debian
    ).each do |os|
      supports os
    end

Signed-off-by: Tim Smith <tsmith@chef.io>