### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "mixlib/shellout"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
 require "bundler/gem_tasks"
 

--- a/chef_dsl_metadata/Rakefile
+++ b/chef_dsl_metadata/Rakefile
@@ -1,6 +1,6 @@
 require "appraisal"
-require "fileutils"
-require "ffi_yajl"
+require "fileutils" unless defined?(FileUtils)
+require "ffi_yajl" unless defined?(FFI_Yajl)
 
 task :generate_chef_metadata do
   require_chef

--- a/lib/foodcritic.rb
+++ b/lib/foodcritic.rb
@@ -1,11 +1,11 @@
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require "treetop"
 require "ripper"
-require "ffi_yajl"
-require "erubis"
+require "ffi_yajl" unless defined?(FFI_Yajl)
+require "erubis" unless defined?(Erubis)
 
 require_relative "foodcritic/chef"
 require_relative "foodcritic/command_line"

--- a/lib/foodcritic/api.rb
+++ b/lib/foodcritic/api.rb
@@ -1,4 +1,4 @@
-require "nokogiri"
+require "nokogiri" unless defined?(Nokogiri)
 require "rufus-lru"
 
 module FoodCritic

--- a/lib/foodcritic/dsl.rb
+++ b/lib/foodcritic/dsl.rb
@@ -1,5 +1,5 @@
-require "open-uri"
-require "pathname"
+require "open-uri" unless defined?(OpenURI)
+require "pathname" unless defined?(Pathname)
 
 module FoodCritic
   # The DSL methods exposed for defining rules. A minimal example rule:

--- a/lib/foodcritic/linter.rb
+++ b/lib/foodcritic/linter.rb
@@ -1,7 +1,7 @@
-require "open-uri"
-require "optparse"
+require "open-uri" unless defined?(OpenURI)
+require "optparse" unless defined?(OptionParser)
 require "ripper"
-require "set"
+require "set" unless defined?(Set)
 
 module FoodCritic
   # The main entry point for linting your Chef cookbooks.

--- a/lib/foodcritic/output.rb
+++ b/lib/foodcritic/output.rb
@@ -1,4 +1,4 @@
-require "set"
+require "set" unless defined?(Set)
 
 module FoodCritic
   class Output

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 require "rspec_command"
 require "simplecov"


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>